### PR TITLE
Implement Options Widget & Track Active Session

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "ts-loader": "^9.4.2",
     "tslint": "^6.1.3",
     "typescript": "^4.9.3",
-    "vscode-debugprotocol": "^1.51.0",
+    "@vscode/debugprotocol": "^1.55.0",
     "webpack": "^5.75.0",
     "webpack-cli": "^5.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "serve": "serve --cors -p 3333"
   },
   "dependencies": {
+    "@vscode/codicons": "^0.0.32",
     "@vscode/webview-ui-toolkit": "^1.2.0",
     "long": "^5.2.1",
     "react": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
       "commandPalette": [
         {
           "command": "memory-inspector.show",
-          "when": "memory-inspector.validDebugger"
+          "when": "memory-inspector.canRead"
         },
         {
           "command": "memory-inspector.show-variable",
@@ -91,7 +91,7 @@
       "debug/variables/context": [
         {
           "command": "memory-inspector.show-variable",
-          "when": "memory-inspector.validDebugger"
+          "when": "memory-inspector.canRead"
         }
       ]
     },

--- a/src/memory-provider.ts
+++ b/src/memory-provider.ts
@@ -36,7 +36,7 @@ export interface LabeledUint8Array extends Uint8Array {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const isInitializeMessage = (message: any): message is DebugProtocol.InitializeResponse => message.command === 'initialize' && message.type === 'response';
 
-export class MemoryProvider {
+export class MemoryProvider { // TODO: A lot
     public static ContextKey = `${manifest.PACKAGE_NAME}.validDebugger`;
 
     public async activate(context: vscode.ExtensionContext): Promise<void> {

--- a/src/memory-provider.ts
+++ b/src/memory-provider.ts
@@ -16,18 +16,7 @@
 
 import * as vscode from 'vscode';
 import * as manifest from './manifest';
-import { DebugProtocol } from 'vscode-debugprotocol';
-
-export interface ReadResponse {
-    address: string;
-    unreadableBytes?: number;
-    data?: string;
-};
-
-export interface WriteResponse {
-    offset?: number;
-    bytesWritten?: number;
-};
+import { DebugProtocol } from '@vscode/debugprotocol';
 
 export interface LabeledUint8Array extends Uint8Array {
     label?: string;
@@ -81,25 +70,25 @@ export class MemoryProvider {
 
     /** Returns the session if the capability is present, otherwise throws. */
     protected assertCapability(capability: keyof DebugProtocol.Capabilities, action: string): vscode.DebugSession {
-        const session = this.getActiveSessionOrThrow(action);
+        const session = this.assertActiveSession(action);
         if (!this.sessions.get(session.id)?.[capability]) {
             throw new Error(`Cannot ${action}. Session does not have capability ${capability}.`);
         }
         return session;
     }
 
-    private getActiveSessionOrThrow(action: string): vscode.DebugSession {
+    private assertActiveSession(action: string): vscode.DebugSession {
         if (!vscode.debug.activeDebugSession) {
             throw new Error(`Cannot ${action}. No active debug session.`);
         }
         return vscode.debug.activeDebugSession;
     }
 
-    public async readMemory(readMemoryArguments: DebugProtocol.ReadMemoryArguments): Promise<ReadResponse | undefined> {
+    public async readMemory(readMemoryArguments: DebugProtocol.ReadMemoryArguments): Promise<DebugProtocol.ReadMemoryResponse> {
         return this.assertCapability('supportsReadMemoryRequest', 'read memory').customRequest('readMemory', readMemoryArguments);
     }
 
-    public async writeMemory(writeMemoryArguments: DebugProtocol.WriteMemoryArguments): Promise<WriteResponse | undefined> {
+    public async writeMemory(writeMemoryArguments: DebugProtocol.WriteMemoryArguments): Promise<DebugProtocol.WriteMemoryResponse> {
         return this.assertCapability('supportsWriteMemoryRequest', 'write memory').customRequest('writeMemory', writeMemoryArguments);
     }
 }

--- a/src/memory-provider.ts
+++ b/src/memory-provider.ts
@@ -17,6 +17,7 @@
 import * as vscode from 'vscode';
 import * as manifest from './manifest';
 import { DebugProtocol } from '@vscode/debugprotocol';
+import { MemoryReadResult, MemoryWriteResult } from './views/memory-webview-common';
 
 export interface LabeledUint8Array extends Uint8Array {
     label?: string;
@@ -84,11 +85,11 @@ export class MemoryProvider {
         return vscode.debug.activeDebugSession;
     }
 
-    public async readMemory(readMemoryArguments: DebugProtocol.ReadMemoryArguments): Promise<DebugProtocol.ReadMemoryResponse> {
+    public async readMemory(readMemoryArguments: DebugProtocol.ReadMemoryArguments): Promise<MemoryReadResult> {
         return this.assertCapability('supportsReadMemoryRequest', 'read memory').customRequest('readMemory', readMemoryArguments);
     }
 
-    public async writeMemory(writeMemoryArguments: DebugProtocol.WriteMemoryArguments): Promise<DebugProtocol.WriteMemoryResponse> {
+    public async writeMemory(writeMemoryArguments: DebugProtocol.WriteMemoryArguments): Promise<MemoryWriteResult> {
         return this.assertCapability('supportsWriteMemoryRequest', 'write memory').customRequest('writeMemory', writeMemoryArguments);
     }
 }

--- a/src/views/components/memory-table.tsx
+++ b/src/views/components/memory-table.tsx
@@ -22,6 +22,7 @@ import {
     VSCodeDataGridCell
 } from '@vscode/webview-ui-toolkit/react';
 import { Memory } from '../memory-webview-view';
+import { Endianness } from './view-types';
 
 interface VariableDecoration {
     name: string;
@@ -71,11 +72,6 @@ interface RowOptions {
     doShowDivider?: boolean;
     index: number;
     isHighlighted?: boolean;
-}
-
-enum Endianness {
-    Little = 'Little Endian',
-    Big = 'Big Endian'
 }
 
 const byteSize = 8;

--- a/src/views/components/memory-table.tsx
+++ b/src/views/components/memory-table.tsx
@@ -86,7 +86,6 @@ const endianness: Endianness = Endianness.Little;
 
 interface MemoryTableProps {
     memory?: Memory;
-    children: React.ReactNode;
 }
 
 export class MemoryTable extends React.Component<MemoryTableProps> {
@@ -161,12 +160,15 @@ export class MemoryTable extends React.Component<MemoryTableProps> {
         let variables = [];
         let isGroupHighlighted = false;
         for (const { node, index, ascii: byteAscii, variables: byteVariables, isHighlighted = false } of this.renderBytes(iteratee, address)) {
-            this.buildGroupByEndianness(bytesInGroup, node);
+            bytesInGroup.push(node);
             ascii += byteAscii;
             variables.push(...byteVariables);
             isGroupHighlighted = isGroupHighlighted || isHighlighted;
             if (bytesInGroup.length === bytesPerGroup || index === iteratee.length - 1) {
                 const itemID = address.add(index);
+                if (endianness === Endianness.Little) {
+                    bytesInGroup.reverse();
+                }
                 yield {
                     node: <span className='byte-group' key={itemID.toString(16)}>{bytesInGroup}</span>,
                     ascii,
@@ -257,14 +259,6 @@ export class MemoryTable extends React.Component<MemoryTableProps> {
             ? ' ' : isPrintableAsAscii(byte) ? String.fromCharCode(byte) : '.';
     }
 
-    protected buildGroupByEndianness(oldBytes: React.ReactNode[], newByte: React.ReactNode): void {
-        if (endianness === Endianness.Big) {
-            oldBytes.push(newByte);
-        } else {
-            oldBytes.unshift(newByte);
-        }
-    }
-
     protected renderRow(options: RowOptions, getRowAttributes = this.getRowAttributes.bind(this)): React.ReactNode {
         const { address, groups } = options;
         const { className, style, title } = getRowAttributes(options);
@@ -276,8 +270,8 @@ export class MemoryTable extends React.Component<MemoryTableProps> {
                 title={title}
                 key={address}
             >
-                <VSCodeDataGridCell gridColumn='1'>{address}</VSCodeDataGridCell>
-                <VSCodeDataGridCell gridColumn='2'>{groups}</VSCodeDataGridCell>
+                <VSCodeDataGridCell style={{ fontFamily: 'var(--vscode-editor-font-family)' }} gridColumn='1'>{address}</VSCodeDataGridCell>
+                <VSCodeDataGridCell style={{ fontFamily: 'var(--vscode-editor-font-family)' }} gridColumn='2'>{groups}</VSCodeDataGridCell>
             </VSCodeDataGridRow>
         );
     }

--- a/src/views/components/memory-table.tsx
+++ b/src/views/components/memory-table.tsx
@@ -21,8 +21,7 @@ import {
     VSCodeDataGridRow,
     VSCodeDataGridCell
 } from '@vscode/webview-ui-toolkit/react';
-import { Memory } from '../memory-webview-view';
-import { Endianness } from './view-types';
+import { Endianness, Memory } from './view-types';
 
 interface VariableDecoration {
     name: string;
@@ -74,14 +73,12 @@ interface RowOptions {
     isHighlighted?: boolean;
 }
 
-const byteSize = 8;
-const bytesPerGroup = 1;
-const groupsPerRow = 4;
-
-const endianness: Endianness = Endianness.Little;
-
 interface MemoryTableProps {
     memory?: Memory;
+    endianness: Endianness;
+    byteSize: number;
+    bytesPerGroup: number;
+    groupsPerRow: number;
 }
 
 export class MemoryTable extends React.Component<MemoryTableProps> {
@@ -118,7 +115,7 @@ export class MemoryTable extends React.Component<MemoryTableProps> {
     }
 
     protected *renderRows(iteratee: Uint8Array, address: Long): IterableIterator<React.ReactNode> {
-        const bytesPerRow = bytesPerGroup * groupsPerRow;
+        const bytesPerRow = this.props.bytesPerGroup * this.props.groupsPerRow;
         let rowsYielded = 0;
         let groups = [];
         let ascii = '';
@@ -129,7 +126,7 @@ export class MemoryTable extends React.Component<MemoryTableProps> {
             ascii += groupAscii;
             variables.push(...groupVariables);
             isRowHighlighted = isRowHighlighted || isHighlighted;
-            if (groups.length === groupsPerRow || index === iteratee.length - 1) {
+            if (groups.length === this.props.groupsPerRow || index === iteratee.length - 1) {
                 const rowAddress = address.add(bytesPerRow * rowsYielded);
                 const options = {
                     address: `0x${rowAddress.toString(16)}`,
@@ -160,9 +157,9 @@ export class MemoryTable extends React.Component<MemoryTableProps> {
             ascii += byteAscii;
             variables.push(...byteVariables);
             isGroupHighlighted = isGroupHighlighted || isHighlighted;
-            if (bytesInGroup.length === bytesPerGroup || index === iteratee.length - 1) {
+            if (bytesInGroup.length === this.props.bytesPerGroup || index === iteratee.length - 1) {
                 const itemID = address.add(index);
-                if (endianness === Endianness.Little) {
+                if (this.props.endianness === Endianness.Little) {
                     bytesInGroup.reverse();
                 }
                 yield {
@@ -181,7 +178,7 @@ export class MemoryTable extends React.Component<MemoryTableProps> {
     }
 
     protected *renderBytes(iteratee: Uint8Array, address: Long): IterableIterator<ByteData> {
-        const itemsPerByte = byteSize / 8;
+        const itemsPerByte = this.props.byteSize / 8;
         let currentByte = 0;
         let chunksInByte: React.ReactNode[] = [];
         let variables: VariableDecoration[] = [];

--- a/src/views/components/memory-widget.tsx
+++ b/src/views/components/memory-widget.tsx
@@ -1,0 +1,81 @@
+/********************************************************************************
+ * Copyright (C) 2022 Ericsson, Arm and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { DebugProtocol } from '@vscode/debugprotocol';
+import React from 'react';
+import { MemoryTable } from './memory-table';
+import { OptionsWidget } from './options-widget';
+import { Endianness, Memory } from './view-types';
+
+interface MemoryWidgetProps {
+    memory?: Memory;
+    memoryReference: string;
+    offset: number;
+    count: number;
+    refreshMemory: () => void;
+    updateMemoryArguments: (memoryArguments: Partial<DebugProtocol.ReadMemoryArguments>) => void;
+}
+
+interface MemoryWidgetState {
+    endianness: Endianness;
+    byteSize: number;
+    bytesPerGroup: number;
+    groupsPerRow: number;
+}
+
+const defaultOptions: MemoryWidgetState = {
+    // columnOptions: [
+    //     { label: 'Variables', doRender: true },
+    //     { label: 'ASCII', doRender: false },
+    // ],
+    endianness: Endianness.Little,
+    byteSize: 8,
+    bytesPerGroup: 1,
+    groupsPerRow: 4,
+};
+
+export class MemoryWidget extends React.Component<MemoryWidgetProps, MemoryWidgetState> {
+    constructor(props: MemoryWidgetProps) {
+        super(props);
+        this.state = { ...defaultOptions };
+    }
+
+    override render(): React.ReactNode {
+        return <>
+            <OptionsWidget
+                memoryReference={this.props.memoryReference}
+                offset={this.props.offset}
+                count={this.props.count}
+                endianness={this.state.endianness}
+                byteSize={this.state.byteSize}
+                bytesPerGroup={this.state.bytesPerGroup}
+                groupsPerRow={this.state.groupsPerRow}
+                updateMemoryArguments={this.props.updateMemoryArguments}
+                updateRenderOptions={this.justSetState}
+                refreshMemory={this.props.refreshMemory}
+            />
+            <MemoryTable
+                memory={this.props.memory}
+                endianness={this.state.endianness}
+                byteSize={this.state.byteSize}
+                bytesPerGroup={this.state.bytesPerGroup}
+                groupsPerRow={this.state.groupsPerRow}
+            />
+        </>;
+    }
+
+    protected justSetState = (newState: Partial<MemoryWidgetState>) => this.setState(prevState => ({ ...prevState, ...newState }));
+}

--- a/src/views/components/memory-widget.tsx
+++ b/src/views/components/memory-widget.tsx
@@ -37,10 +37,6 @@ interface MemoryWidgetState {
 }
 
 const defaultOptions: MemoryWidgetState = {
-    // columnOptions: [
-    //     { label: 'Variables', doRender: true },
-    //     { label: 'ASCII', doRender: false },
-    // ],
     endianness: Endianness.Little,
     byteSize: 8,
     bytesPerGroup: 1,
@@ -64,7 +60,7 @@ export class MemoryWidget extends React.Component<MemoryWidgetProps, MemoryWidge
                 bytesPerGroup={this.state.bytesPerGroup}
                 groupsPerRow={this.state.groupsPerRow}
                 updateMemoryArguments={this.props.updateMemoryArguments}
-                updateRenderOptions={this.justSetState}
+                updateRenderOptions={this.updateRenderOptions}
                 refreshMemory={this.props.refreshMemory}
             />
             <MemoryTable
@@ -77,5 +73,5 @@ export class MemoryWidget extends React.Component<MemoryWidgetProps, MemoryWidge
         </>;
     }
 
-    protected justSetState = (newState: Partial<MemoryWidgetState>) => this.setState(prevState => ({ ...prevState, ...newState }));
+    protected updateRenderOptions = (newState: Partial<MemoryWidgetState>) => this.setState(prevState => ({ ...prevState, ...newState }));
 }

--- a/src/views/components/options-widget.tsx
+++ b/src/views/components/options-widget.tsx
@@ -1,0 +1,91 @@
+/********************************************************************************
+ * Copyright (C) 2023 Ericsson, Arm and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import React from 'react';
+import type { DebugProtocol } from '@vscode/debugprotocol';
+import { Endianness, TableRenderOptions } from './view-types';
+import { VSCodeButton, VSCodeDropdown, VSCodeOption, VSCodeTextField } from '@vscode/webview-ui-toolkit/react';
+
+interface OptionsWidgetState extends DebugProtocol.ReadMemoryArguments, TableRenderOptions { }
+
+interface OptionsWidgetProps {
+    updateRenderOptions: (options: TableRenderOptions) => void;
+    updateMemoryArguments: (memoryArguments: DebugProtocol.ReadMemoryArguments) => void;
+}
+
+const defaultOptions: OptionsWidgetState = {
+    memoryReference: '',
+    offset: 0,
+    count: 256,
+    columnOptions: [
+        { label: 'Variables', doRender: true },
+        { label: 'ASCII', doRender: false },
+    ],
+    endianness: Endianness.Little,
+    byteSize: 8,
+    bytesPerGroup: 1,
+    groupsPerRow: 4,
+};
+
+export class OptionsWidget extends React.Component<OptionsWidgetProps, OptionsWidgetState> {
+    constructor(props: OptionsWidgetProps) {
+        super(props);
+        this.state = { ...defaultOptions };
+    }
+
+    override render(): React.ReactNode {
+        return <div>
+            <div className="title-bar">
+                <div className="title"></div>
+                <div className="settings-toggle"></div>
+            </div>
+            <div className="core-options">
+                <VSCodeTextField>Address</VSCodeTextField>
+                <VSCodeTextField>Offset</VSCodeTextField>
+                <VSCodeTextField>Length</VSCodeTextField>
+                <VSCodeButton>Go</VSCodeButton>
+            </div>
+            <div className="advanced-options">
+                <label htmlFor="bytes-per-group">Bytes per Group</label>
+                <VSCodeDropdown id="bytes-per-group">
+                    <VSCodeOption>1</VSCodeOption>
+                    <VSCodeOption>2</VSCodeOption>
+                    <VSCodeOption>4</VSCodeOption>
+                    <VSCodeOption>8</VSCodeOption>
+                    <VSCodeOption>16</VSCodeOption>
+                </VSCodeDropdown>
+                <label htmlFor="groups-per-row">Groups per Row</label>
+                <VSCodeDropdown id="groups-per-row">
+                    <VSCodeOption>1</VSCodeOption>
+                    <VSCodeOption>2</VSCodeOption>
+                    <VSCodeOption>4</VSCodeOption>
+                    <VSCodeOption>8</VSCodeOption>
+                    <VSCodeOption>16</VSCodeOption>
+                    <VSCodeOption>32</VSCodeOption>
+                </VSCodeDropdown>
+                <label>Columns</label>
+                <div className="multi-select-checkbox">
+                    <input type="checkbox" id="variables" />
+                    <label htmlFor="variables">Variables</label>
+                </div>
+                <div className="multi-select-checkbox">
+                    <input type="checkbox" id="ascii" />
+                    <label htmlFor="ascii">ASCII</label>
+                </div>
+            </div>
+        </div>;
+    }
+}

--- a/src/views/components/options-widget.tsx
+++ b/src/views/components/options-widget.tsx
@@ -38,17 +38,11 @@ const enum InputId {
     Length = 'length',
     BytesPerGroup = 'bytes-per-group',
     GroupsPerRow = 'groups-per-row',
-    Variables = 'variables',
-    Ascii = 'ascii',
 }
 
 export class OptionsWidget extends React.Component<OptionsWidgetProps, {}> {
     override render(): React.ReactNode {
-        return <div>
-            <div className="title-bar">
-                <div className="title"></div>
-                <div className="settings-toggle"></div>
-            </div>
+        return <div className='memory-options-widget'>
             <div className="core-options">
                 <VSCodeTextField id={InputId.Address} onChange={this.handleInputChange} value={this.props.memoryReference}>Address</VSCodeTextField>
                 <VSCodeTextField id={InputId.Offset} onChange={this.handleInputChange} value={this.props.offset.toString()}>Offset</VSCodeTextField>
@@ -73,15 +67,6 @@ export class OptionsWidget extends React.Component<OptionsWidgetProps, {}> {
                     <VSCodeOption>16</VSCodeOption>
                     <VSCodeOption>32</VSCodeOption>
                 </VSCodeDropdown>
-                <label>Columns</label>
-                <div className="multi-select-checkbox">
-                    <input type="checkbox" id={InputId.Variables} checked={false} />
-                    <label htmlFor={InputId.Variables}>Variables</label>
-                </div>
-                <div className="multi-select-checkbox">
-                    <input type="checkbox" id={InputId.Ascii} checked={false} />
-                    <label htmlFor={InputId.Ascii}>ASCII</label>
-                </div>
             </div>
         </div>;
     }

--- a/src/views/components/options-widget.tsx
+++ b/src/views/components/options-widget.tsx
@@ -19,33 +19,30 @@ import type { DebugProtocol } from '@vscode/debugprotocol';
 import { Endianness, TableRenderOptions } from './view-types';
 import { VSCodeButton, VSCodeDropdown, VSCodeOption, VSCodeTextField } from '@vscode/webview-ui-toolkit/react';
 
-interface OptionsWidgetState extends DebugProtocol.ReadMemoryArguments, TableRenderOptions { }
-
 interface OptionsWidgetProps {
-    updateRenderOptions: (options: TableRenderOptions) => void;
-    updateMemoryArguments: (memoryArguments: DebugProtocol.ReadMemoryArguments) => void;
+    updateRenderOptions: (options: Partial<TableRenderOptions>) => void;
+    updateMemoryArguments: (memoryArguments: Partial<DebugProtocol.ReadMemoryArguments>) => void;
+    refreshMemory: () => void;
+    memoryReference: string;
+    offset: number;
+    count: number;
+    endianness: Endianness;
+    byteSize: number;
+    bytesPerGroup: number;
+    groupsPerRow: number;
 }
 
-const defaultOptions: OptionsWidgetState = {
-    memoryReference: '',
-    offset: 0,
-    count: 256,
-    columnOptions: [
-        { label: 'Variables', doRender: true },
-        { label: 'ASCII', doRender: false },
-    ],
-    endianness: Endianness.Little,
-    byteSize: 8,
-    bytesPerGroup: 1,
-    groupsPerRow: 4,
-};
+const enum InputId {
+    Address = 'address',
+    Offset = 'offset',
+    Length = 'length',
+    BytesPerGroup = 'bytes-per-group',
+    GroupsPerRow = 'groups-per-row',
+    Variables = 'variables',
+    Ascii = 'ascii',
+}
 
-export class OptionsWidget extends React.Component<OptionsWidgetProps, OptionsWidgetState> {
-    constructor(props: OptionsWidgetProps) {
-        super(props);
-        this.state = { ...defaultOptions };
-    }
-
+export class OptionsWidget extends React.Component<OptionsWidgetProps, {}> {
     override render(): React.ReactNode {
         return <div>
             <div className="title-bar">
@@ -53,22 +50,22 @@ export class OptionsWidget extends React.Component<OptionsWidgetProps, OptionsWi
                 <div className="settings-toggle"></div>
             </div>
             <div className="core-options">
-                <VSCodeTextField>Address</VSCodeTextField>
-                <VSCodeTextField>Offset</VSCodeTextField>
-                <VSCodeTextField>Length</VSCodeTextField>
-                <VSCodeButton>Go</VSCodeButton>
+                <VSCodeTextField id={InputId.Address} onChange={this.handleInputChange} value={this.props.memoryReference}>Address</VSCodeTextField>
+                <VSCodeTextField id={InputId.Offset} onChange={this.handleInputChange} value={this.props.offset.toString()}>Offset</VSCodeTextField>
+                <VSCodeTextField id={InputId.Length} onChange={this.handleInputChange} value={this.props.count.toString()}>Length</VSCodeTextField>
+                <VSCodeButton onClick={this.props.refreshMemory}>Go</VSCodeButton>
             </div>
             <div className="advanced-options">
-                <label htmlFor="bytes-per-group">Bytes per Group</label>
-                <VSCodeDropdown id="bytes-per-group">
+                <label htmlFor={InputId.BytesPerGroup}>Bytes per Group</label>
+                <VSCodeDropdown id={InputId.BytesPerGroup} onChange={this.handleInputChange} value={this.props.bytesPerGroup.toString()}>
                     <VSCodeOption>1</VSCodeOption>
                     <VSCodeOption>2</VSCodeOption>
                     <VSCodeOption>4</VSCodeOption>
                     <VSCodeOption>8</VSCodeOption>
                     <VSCodeOption>16</VSCodeOption>
                 </VSCodeDropdown>
-                <label htmlFor="groups-per-row">Groups per Row</label>
-                <VSCodeDropdown id="groups-per-row">
+                <label htmlFor={InputId.GroupsPerRow}>Groups per Row</label>
+                <VSCodeDropdown id={InputId.GroupsPerRow} onChange={this.handleInputChange} value={this.props.groupsPerRow.toString()}>
                     <VSCodeOption>1</VSCodeOption>
                     <VSCodeOption>2</VSCodeOption>
                     <VSCodeOption>4</VSCodeOption>
@@ -78,14 +75,28 @@ export class OptionsWidget extends React.Component<OptionsWidgetProps, OptionsWi
                 </VSCodeDropdown>
                 <label>Columns</label>
                 <div className="multi-select-checkbox">
-                    <input type="checkbox" id="variables" />
-                    <label htmlFor="variables">Variables</label>
+                    <input type="checkbox" id={InputId.Variables} checked={false} />
+                    <label htmlFor={InputId.Variables}>Variables</label>
                 </div>
                 <div className="multi-select-checkbox">
-                    <input type="checkbox" id="ascii" />
-                    <label htmlFor="ascii">ASCII</label>
+                    <input type="checkbox" id={InputId.Ascii} checked={false} />
+                    <label htmlFor={InputId.Ascii}>ASCII</label>
                 </div>
             </div>
         </div>;
+    }
+
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+    handleInputChange: React.FormEventHandler<HTMLInputElement> & ((event: Event) => unknown) = e => this.doHandleChangeEvent(e as any);
+
+    protected doHandleChangeEvent(event: React.FormEvent<HTMLInputElement>): unknown {
+        const id = event.currentTarget.id as InputId;
+        switch (id) {
+            case InputId.Address: return this.props.updateMemoryArguments({ memoryReference: event.currentTarget.value });
+            case InputId.Offset: return !Number.isNaN(event.currentTarget.value) && this.props.updateMemoryArguments({ offset: Number(event.currentTarget.value) });
+            case InputId.Length: return !Number.isNaN(event.currentTarget.value) && this.props.updateMemoryArguments({ count: Number(event.currentTarget.value) });
+            case InputId.BytesPerGroup: return this.props.updateRenderOptions({ bytesPerGroup: Number(event.currentTarget.value) });
+            case InputId.GroupsPerRow: return this.props.updateRenderOptions({ groupsPerRow: Number(event.currentTarget.value) });
+        }
     }
 }

--- a/src/views/components/view-types.ts
+++ b/src/views/components/view-types.ts
@@ -14,9 +14,16 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+import Long from 'long';
+
 export enum Endianness {
     Little = 'Little Endian',
     Big = 'Big Endian'
+}
+
+export interface Memory {
+    address: Long;
+    bytes: Uint8Array;
 }
 
 export interface TableRenderOptions {

--- a/src/views/components/view-types.ts
+++ b/src/views/components/view-types.ts
@@ -1,0 +1,28 @@
+/********************************************************************************
+ * Copyright (C) 2023 Ericsson, Arm and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+export enum Endianness {
+    Little = 'Little Endian',
+    Big = 'Big Endian'
+}
+
+export interface TableRenderOptions {
+    columnOptions: Array<{ label: string, doRender: boolean }>;
+    endianness: Endianness;
+    bytesPerGroup: number;
+    groupsPerRow: number;
+    byteSize: number;
+}

--- a/src/views/memory-webview-common.ts
+++ b/src/views/memory-webview-common.ts
@@ -17,17 +17,11 @@
 import type { DebugProtocol } from '@vscode/debugprotocol';
 import { NotificationType, RequestType } from 'vscode-messenger-common';
 
-export interface MemoryOptions {
-    startAddress: number;
-    locationOffset: number;
-    readLength: number;
-}
-
 export type MemoryReadResult = DebugProtocol.ReadMemoryResponse['body'];
 export type MemoryWriteResult = DebugProtocol.WriteMemoryResponse['body'];
 
 export const readyType: NotificationType<void> = { method: 'ready' };
 export const logMessageType: RequestType<string, void> = { method: 'logMessage' };
-export const setOptionsType: RequestType<MemoryOptions, void> = { method: 'setOptions' };
+export const setOptionsType: RequestType<Partial<DebugProtocol.ReadMemoryArguments | undefined>, void> = { method: 'setOptions' };
 export const readMemoryType: RequestType<DebugProtocol.ReadMemoryArguments, MemoryReadResult> = { method: 'readMemory' };
 export const writeMemoryType: RequestType<DebugProtocol.WriteMemoryArguments, MemoryWriteResult> = { method: 'writeMemory' };

--- a/src/views/memory-webview-common.ts
+++ b/src/views/memory-webview-common.ts
@@ -14,6 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+import type { DebugProtocol } from '@vscode/debugprotocol';
 import { NotificationType, RequestType } from 'vscode-messenger-common';
 
 export interface MemoryOptions {
@@ -22,25 +23,8 @@ export interface MemoryOptions {
     readLength: number;
 }
 
-export interface MemoryReadRequest {
-    memoryReference: string;
-    count: number;
-    offset?: number;
-}
-
-export interface MemoryReadResponse {
-    address: string;
-    data: string;
-}
-
-export interface MemoryWriteRequest {
-    memoryReference: string;
-    data: string;
-    offset: number;
-}
-
 export const readyType: NotificationType<void> = { method: 'ready' };
 export const logMessageType: RequestType<string, void> = { method: 'logMessage' };
 export const setOptionsType: RequestType<MemoryOptions, void> = { method: 'setOptions' };
-export const readMemoryType: RequestType<MemoryReadRequest, MemoryReadResponse> = { method: 'readMemory' };
-export const writeMemoryType: RequestType<MemoryWriteRequest, number> = { method: 'writeMemory' };
+export const readMemoryType: RequestType<DebugProtocol.ReadMemoryArguments, DebugProtocol.ReadMemoryResponse> = { method: 'readMemory' };
+export const writeMemoryType: RequestType<DebugProtocol.WriteMemoryArguments, DebugProtocol.WriteMemoryResponse> = { method: 'writeMemory' };

--- a/src/views/memory-webview-common.ts
+++ b/src/views/memory-webview-common.ts
@@ -23,8 +23,11 @@ export interface MemoryOptions {
     readLength: number;
 }
 
+export type MemoryReadResult = DebugProtocol.ReadMemoryResponse['body'];
+export type MemoryWriteResult = DebugProtocol.WriteMemoryResponse['body'];
+
 export const readyType: NotificationType<void> = { method: 'ready' };
 export const logMessageType: RequestType<string, void> = { method: 'logMessage' };
 export const setOptionsType: RequestType<MemoryOptions, void> = { method: 'setOptions' };
-export const readMemoryType: RequestType<DebugProtocol.ReadMemoryArguments, DebugProtocol.ReadMemoryResponse> = { method: 'readMemory' };
-export const writeMemoryType: RequestType<DebugProtocol.WriteMemoryArguments, DebugProtocol.WriteMemoryResponse> = { method: 'writeMemory' };
+export const readMemoryType: RequestType<DebugProtocol.ReadMemoryArguments, MemoryReadResult> = { method: 'readMemory' };
+export const writeMemoryType: RequestType<DebugProtocol.WriteMemoryArguments, MemoryWriteResult> = { method: 'writeMemory' };

--- a/src/views/memory-webview-view.tsx
+++ b/src/views/memory-webview-view.tsx
@@ -70,12 +70,12 @@ class App extends React.Component<{}, MemoryState> {
             memoryReference={this.state.memoryReference}
             offset={this.state.offset}
             count={this.state.count}
-            updateMemoryArguments={this.justSetState}
+            updateMemoryArguments={this.updateMemoryState}
             refreshMemory={this.refreshMemory}
         />;
     }
 
-    protected justSetState = (newState: Partial<MemoryState>) => this.setState(prevState => ({ ...prevState, ...newState }));
+    protected updateMemoryState = (newState: Partial<MemoryState>) => this.setState(prevState => ({ ...prevState, ...newState }));
 
     protected async setOptions(options?: Partial<DebugProtocol.ReadMemoryArguments>): Promise<void> {
         this.messenger.sendRequest(logMessageType, HOST_EXTENSION, JSON.stringify(options));

--- a/src/views/memory-webview-view.tsx
+++ b/src/views/memory-webview-view.tsx
@@ -28,6 +28,7 @@ import {
     readMemoryType
 } from './memory-webview-common';
 import type { DebugProtocol } from '@vscode/debugprotocol';
+import { OptionsWidget } from './components/options-widget';
 
 export interface Memory {
     address: Long;
@@ -65,6 +66,7 @@ class App extends React.Component<{}, MemoryState> {
         const { memory } = this.state;
         return (
             <div>
+                <OptionsWidget updateMemoryArguments={() => { }} updateRenderOptions={() => { }} />
                 <MemoryTable memory={memory} />
             </div>
         );

--- a/src/views/memory-webview-view.tsx
+++ b/src/views/memory-webview-view.tsx
@@ -65,8 +65,7 @@ class App extends React.Component<{}, MemoryState> {
         const { memory } = this.state;
         return (
             <div>
-                <MemoryTable memory={memory}>
-                </MemoryTable>
+                <MemoryTable memory={memory} />
             </div>
         );
     }
@@ -81,7 +80,7 @@ class App extends React.Component<{}, MemoryState> {
         });
 
         this.setState({
-            memory: this.convertMemory(response.body)
+            memory: this.convertMemory(response)
         });
     }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "target": "es6",
+        "target": "ES2020",
         "module": "commonjs",
         "strict": true,
         "sourceMap": true,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -77,6 +77,7 @@ module.exports = [
                 buffer: require.resolve('buffer')
             }
         },
+        optimization: { minimize: false },
         plugins: [
             new webpack.ProvidePlugin({
                 Buffer: ['buffer', 'Buffer']

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -77,7 +77,6 @@ module.exports = [
                 buffer: require.resolve('buffer')
             }
         },
-        optimization: { minimize: false },
         plugins: [
             new webpack.ProvidePlugin({
                 Buffer: ['buffer', 'Buffer']

--- a/yarn.lock
+++ b/yarn.lock
@@ -338,6 +338,11 @@
     "@typescript-eslint/types" "5.45.0"
     eslint-visitor-keys "^3.3.0"
 
+"@vscode/codicons@^0.0.32":
+  version "0.0.32"
+  resolved "https://registry.yarnpkg.com/@vscode/codicons/-/codicons-0.0.32.tgz#9e27de90d509c69762b073719ba3bf46c3cd2530"
+  integrity sha512-3lgSTWhAzzWN/EPURoY4ZDBEA80OPmnaknNujA3qnI4Iu7AONWd9xF3iE4L+4prIe8E3TUnLQ4pxoaFTEEZNwg==
+
 "@vscode/debugprotocol@^1.55.0":
   version "1.59.0"
   resolved "https://registry.yarnpkg.com/@vscode/debugprotocol/-/debugprotocol-1.59.0.tgz#f173ff725f60e4ff1002f089105634900c88bd77"

--- a/yarn.lock
+++ b/yarn.lock
@@ -338,6 +338,11 @@
     "@typescript-eslint/types" "5.45.0"
     eslint-visitor-keys "^3.3.0"
 
+"@vscode/debugprotocol@^1.55.0":
+  version "1.59.0"
+  resolved "https://registry.yarnpkg.com/@vscode/debugprotocol/-/debugprotocol-1.59.0.tgz#f173ff725f60e4ff1002f089105634900c88bd77"
+  integrity sha512-Ks8NiZrCvybf9ebGLP8OUZQbEMIJYC8X0Ds54Q/szpT/SYEDjTksPvZlcWGTo7B9t5abjvbd0jkNH3blYaSuVw==
+
 "@vscode/vsce@^2.15.0":
   version "2.15.0"
   resolved "https://registry.yarnpkg.com/@vscode/vsce/-/vsce-2.15.0.tgz#fe48873d2204dcd5912d1384a889112cb219da65"
@@ -3193,11 +3198,6 @@ vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==
-
-vscode-debugprotocol@^1.51.0:
-  version "1.51.0"
-  resolved "https://registry.yarnpkg.com/vscode-debugprotocol/-/vscode-debugprotocol-1.51.0.tgz#c03168dac778b6c24ce17b3511cb61e89c11b2df"
-  integrity sha512-dzKWTMMyebIMPF1VYMuuQj7gGFq7guR8AFya0mKacu+ayptJfaRuM0mdHCqiOth4FnRP8mPhEroFPx6Ift8wHA==
 
 vscode-messenger-common@^0.4.3:
   version "0.4.3"


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/blob/main/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #6, Closes #7, Resolves #8.

- Modifies the Memory Provider to maintain a list of capabilities for each active debug session so that it can behave appropriately according to the capabilities of that session.
- Splits the `validDebugger` context key into `canRead` and `canWrite`, since reading and writing capabilities are separate.
- Changes the font for the data and address display to the `--vscode-editor-font-family` so that it is a monospace font.
- Adds a view to the panel that controls the memory parameters (reference, offset, count) and the render parameters (bytes/group, groups/row, endianness) and updates the view appropriately.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Access some memory and confirm that the data (but not column headers) are displayed in a monospace font.
---
1. Run two debug sessions simultaneously, one that can read memory and one that cannot - try starting them in different orders.
2. Confirm that the context menu items are available for variables in the session that can read memory but not for variables in the session that cannot.
---
1. Open a memory view
2. Use the configuration view to change the parameters of the memory fetch.
3. Confirm that clicking `Go` fetches memory that matches the parameters entered.
4. With memory loaded, modify the render parameters and confirm that the view behaves as expected.

#### Review checklist

To be continued...

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
