### PR TITLE
Fix bugs / leftovers from variable decorations

### DIFF
--- a/src/plugin/adapter-registry/adapter-capabilities.ts
+++ b/src/plugin/adapter-registry/adapter-capabilities.ts
@@ -117,7 +117,7 @@ export class VariableTracker {
     }
 
     initializeAdapterTracker(session: vscode.DebugSession): AdapterVariableTracker | undefined {
-        if (session.type === 'gdb') {
+        if (this.types.includes(session.type)) {
             const sessionTracker = new this.TrackerConstructor(new vscode.Disposable(() => this.sessions.delete(session.id)), this.logger);
             this.sessions.set(session.id, sessionTracker);
             return sessionTracker;

--- a/src/plugin/memory-webview-main.ts
+++ b/src/plugin/memory-webview-main.ts
@@ -133,14 +133,27 @@ export class MemoryWebview {
     }
 
     protected async readMemory(request: DebugProtocol.ReadMemoryArguments): Promise<MemoryReadResult> {
-        return this.memoryProvider.readMemory(request);
+        try {
+            return await this.memoryProvider.readMemory(request);
+        } catch (err) {
+            outputChannelLogger.error('Error fetching memory', err instanceof Error ? `: ${err.message}\n${err.stack}` : '');
+        }
     }
 
     protected async writeMemory(request: DebugProtocol.WriteMemoryArguments): Promise<MemoryWriteResult> {
-        return this.memoryProvider.writeMemory(request);
+        try {
+            return await this.memoryProvider.writeMemory(request);
+        } catch (err) {
+            outputChannelLogger.error('Error writing memory', err instanceof Error ? `: ${err.message}\n${err.stack}` : '');
+        }
     }
 
     protected async getVariables(request: DebugProtocol.ReadMemoryArguments): Promise<VariableRange[]> {
-        return this.memoryProvider.getVariables(request);
+        try {
+            return await this.memoryProvider.getVariables(request);
+        } catch (err) {
+            outputChannelLogger.error('Error fetching variables', err instanceof Error ? `: ${err.message}\n${err.stack}` : '');
+            return [];
+        }
     }
 }

--- a/src/webview/components/memory-table.tsx
+++ b/src/webview/components/memory-table.tsx
@@ -99,7 +99,7 @@ export class MemoryTable extends React.Component<MemoryTableProps> {
                         <VSCodeDataGridCell cellType='columnheader' gridColumn='2'>
                             Groups
                         </VSCodeDataGridCell>
-                        {this.props.columns.map(({ contribution }, index) => <VSCodeDataGridCell cellType='columnheader' gridColumn={(index + 3).toString()}>
+                        {this.props.columns.map(({ contribution }, index) => <VSCodeDataGridCell key={contribution.id} cellType='columnheader' gridColumn={(index + 3).toString()}>
                             {contribution.label}
                         </VSCodeDataGridCell>)}
                     </VSCodeDataGridRow>
@@ -115,7 +115,10 @@ export class MemoryTable extends React.Component<MemoryTableProps> {
                 <VSCodeDataGridRow gridTemplateColumns={new Array(this.props.columns.length + 2).fill('1fr').join(' ')}>
                     <VSCodeDataGridCell gridColumn='1'>No Data</VSCodeDataGridCell>
                     <VSCodeDataGridCell gridColumn='2'>No Data</VSCodeDataGridCell>
-                    {this.props.columns.map((column, index) => column.active && <VSCodeDataGridCell gridColumn={(index + 3).toString()}>No Data</VSCodeDataGridCell>)}
+                    {this.props.columns.map((column, index) =>
+                        column.active
+                        && <VSCodeDataGridCell key={column.contribution.id} gridColumn={(index + 3).toString()}>No Data</VSCodeDataGridCell>
+                    )}
                 </VSCodeDataGridRow>
             );
         }
@@ -280,10 +283,11 @@ export class MemoryTable extends React.Component<MemoryTableProps> {
             >
                 <VSCodeDataGridCell style={{ fontFamily: 'var(--vscode-editor-font-family)' }} gridColumn='1'>{addressString}</VSCodeDataGridCell>
                 <VSCodeDataGridCell style={{ fontFamily: 'var(--vscode-editor-font-family)' }} gridColumn='2'>{groups}</VSCodeDataGridCell>
-                {this.props.columns.map((column, index) => <VSCodeDataGridCell style={{ fontFamily: 'var(--vscode-editor-font-family)' }} gridColumn={(index + 3).toString()}>
-                    {column.contribution.render(range, this.props.memory!)}
-                </VSCodeDataGridCell>
-                )}
+                {this.props.columns.map((column, index) => (
+                    <VSCodeDataGridCell key={column.contribution.id} style={{ fontFamily: 'var(--vscode-editor-font-family)' }} gridColumn={(index + 3).toString()}>
+                        {column.contribution.render(range, this.props.memory!)}
+                    </VSCodeDataGridCell>
+                ))}
             </VSCodeDataGridRow>
         );
     }

--- a/src/webview/variables/variable-decorations.ts
+++ b/src/webview/variables/variable-decorations.ts
@@ -75,14 +75,14 @@ export class VariableDecorator implements ColumnContribution, Decorator {
 
     render(range: BigIntMemoryRange): ReactNode {
         return this.getVariablesInRange(range)?.reduce<ReactNode[]>((result, current, index) => {
-            if (index > 0) { result.push(','); }
-            result.push(React.createElement('span', { style: { color: current.color } }, current.variable.name));
+            if (index > 0) { result.push(', '); }
+            result.push(React.createElement('span', { style: { color: current.color }, key: current.variable.name }, current.variable.name));
             return result;
         }, []);
     }
 
     /** Returns variables that start in the given range. */
-    protected lastCall?: BigInt;
+    protected lastCall?: bigint;
     protected currentIndex = 0;
     protected getVariablesInRange(range: BigIntMemoryRange): Array<{ variable: BigIntVariableRange, color: string }> | undefined {
         if (!this.currentVariables?.length) { return undefined; }
@@ -115,7 +115,7 @@ export class VariableDecorator implements ColumnContribution, Decorator {
                         startAddress: variable.startAddress,
                         endAddress: variable.endAddress
                     },
-                    style: { color: NON_HC_COLORS[colorIndex++] }
+                    style: { color: NON_HC_COLORS[colorIndex++ % 5] }
                 });
             }
         }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/blob/main/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #19

Attempting to use the variable decorations on more than toy programs revealed some bugs, and this PR addresses them.
 - Adds keys to React elements generated as arrays.
 - Makes sure that decorations cycle through colors correctly by adding a mod operation.
 - Adds a space to the variable name separator (`, `).
 - Removes a check for Locals in the variable handler, replacing it with an extensible check for 'not register'.
 - Adds logging of failures when retrieving memory, so that they show more details than just the message and aren't displayed to the user by default.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Retrieve memory from a program with more than 5 variables
2. Ensure that the data display for all regions populated by variables is colored, not just the first 5.
3. If two variables begin on the same line, confirm that their names are separated by `, ` and not just `,`.
4. Check the developer console for messages about components missing keys.


#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
