### PR TITLE
Refresh view when debug stopped

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,6 +110,19 @@
           ],
           "default": "warn",
           "description": "Specify the logging verbosity of the memory inspector extension"
+        },
+        "memory-inspector.refreshOnStop": {
+          "type": "string",
+          "enum": [
+            "on",
+            "off"
+          ],
+          "enumDescriptions": [
+            "Refresh memory views when when debugger stops (e.g. a breakpoint is hit)",
+            "Memory view data is manually refreshed by user"
+          ],
+          "default": "on",
+          "description": "Refresh memory views when debugger stops"
         }
       }
     }

--- a/src/plugin/manifest.ts
+++ b/src/plugin/manifest.ts
@@ -18,3 +18,5 @@ export const PACKAGE_NAME = 'memory-inspector';
 export const DISPLAY_NAME = 'Memory Inspector';
 export const CONFIG_LOGGING_VERBOSITY = 'loggingVerbosity';
 export const DEFAULT_LOGGING_VERBOSITY = 'warn';
+export const CONFIG_REFRESH_ON_STOP = 'refreshOnStop';
+export const DEFAULT_REFRESH_ON_STOP = 'on';

--- a/src/plugin/memory-webview-main.ts
+++ b/src/plugin/memory-webview-main.ts
@@ -123,6 +123,7 @@ export class MemoryWebview {
             this.messenger.onRequest(readMemoryType, request => this.readMemory(request), { sender: participant }),
             this.messenger.onRequest(writeMemoryType, request => this.writeMemory(request), { sender: participant }),
             this.messenger.onRequest(getVariables, request => this.getVariables(request), { sender: participant }),
+            this.memoryProvider.onDidStopDebug(() => this.refresh(participant))
         ];
 
         panel.onDidDispose(() => disposables.forEach(disposible => disposible.dispose()));

--- a/src/plugin/memory-webview-main.ts
+++ b/src/plugin/memory-webview-main.ts
@@ -40,6 +40,11 @@ interface Variable {
     memoryReference: number;
 }
 
+enum RefreshEnum {
+    off = 0,
+    on = 1
+}
+
 const isMemoryVariable = (variable: Variable): variable is Variable => variable && !!(variable as Variable).memoryReference;
 
 export class MemoryWebview {
@@ -48,9 +53,17 @@ export class MemoryWebview {
     public static VariableCommandType = `${manifest.PACKAGE_NAME}.show-variable`;
 
     protected messenger: Messenger;
+    protected refreshOnStop: RefreshEnum;
 
     public constructor(protected extensionUri: vscode.Uri, protected memoryProvider: MemoryProvider) {
         this.messenger = new Messenger();
+
+        this.refreshOnStop = this.getRefresh();
+        vscode.workspace.onDidChangeConfiguration(e => {
+            if (e.affectsConfiguration(`${manifest.PACKAGE_NAME}.${manifest.CONFIG_REFRESH_ON_STOP}`)) {
+                this.refreshOnStop = this.getRefresh();
+            }
+        });
     }
 
     public activate(context: vscode.ExtensionContext): void {
@@ -84,6 +97,11 @@ export class MemoryWebview {
         // Sets up an event listener to listen for messages passed from the webview view context
         // and executes code based on the message that is recieved
         this.setWebviewMessageListener(panel, initialMemory);
+    }
+
+    protected getRefresh(): RefreshEnum {
+        const config = vscode.workspace.getConfiguration(manifest.PACKAGE_NAME).get<string>(manifest.CONFIG_REFRESH_ON_STOP) || manifest.DEFAULT_REFRESH_ON_STOP;
+        return RefreshEnum[config as keyof typeof RefreshEnum];
     }
 
     protected async getWebviewContent(panel: vscode.WebviewPanel): Promise<void> {
@@ -123,7 +141,11 @@ export class MemoryWebview {
             this.messenger.onRequest(readMemoryType, request => this.readMemory(request), { sender: participant }),
             this.messenger.onRequest(writeMemoryType, request => this.writeMemory(request), { sender: participant }),
             this.messenger.onRequest(getVariables, request => this.getVariables(request), { sender: participant }),
-            this.memoryProvider.onDidStopDebug(() => this.refresh(participant))
+            this.memoryProvider.onDidStopDebug(() => {
+                if (this.refreshOnStop === RefreshEnum.on) {
+                    this.refresh(participant);
+                }
+            })
         ];
 
         panel.onDidDispose(() => disposables.forEach(disposible => disposible.dispose()));


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/blob/main/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

With reference to https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/issues/11, this PR refreshes the memory view when the debugger stops (e.g. for each step)

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Open a memory view and step the debugger. Watch values change

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
