### PR TITLE
Paginate memory

### DIFF
--- a/media/memory-inspector.css
+++ b/media/memory-inspector.css
@@ -1,0 +1,65 @@
+/********************************************************************************
+ * Copyright (C) 2023 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+
+ .bytes-select {
+    color: var(--vscode-dropdown-forground);
+    border-radius: 2px;
+    font-size: var(--vscode-font-size);
+    border: 1px solid var(--vscode-dropdown-border);
+    background: var(--vscode-dropdown-background);
+    outline: none;
+    cursor: pointer;
+    padding-top: 3px;
+  }
+
+ .more-memory-select {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    font-style: italic;
+    cursor: pointer;
+  }
+  
+  .more-memory-select-top {
+    display: flex;
+    justify-content: center;
+    height: 16px;
+    padding-bottom: 1px;
+    transition: border-color 0.1s;
+    border-color: transparent;
+  }
+  
+  .more-memory-select-top:hover {
+    border-bottom: 1px solid;
+    padding-bottom: 0;
+    border-color: var(--vscode-sideBar-foreground);
+  }
+  
+  .more-memory-select select {
+    border: none;
+    background: none;
+    border-radius: 3px;
+    margin: 0 2px;
+    position: relative;
+    bottom: 1px;
+    transition: background 0.1s;
+    font-style: italic;
+  }
+  
+  .more-memory-select select:hover {
+    background: var(--vscode-dropdown-background);
+  }

--- a/src/plugin/memory-webview-main.ts
+++ b/src/plugin/memory-webview-main.ts
@@ -114,6 +114,7 @@ export class MemoryWebview {
 
         const cspSrc = panel.webview.cspSource;
         const codiconsUri = panel.webview.asWebviewUri(vscode.Uri.joinPath(this.extensionUri, 'node_modules', '@vscode/codicons', 'dist', 'codicon.css'));
+        const memoryInspectorCSS = panel.webview.asWebviewUri(vscode.Uri.joinPath(this.extensionUri, 'media', 'memory-inspector.css'));
 
         panel.webview.html = `
             <!DOCTYPE html>
@@ -124,6 +125,7 @@ export class MemoryWebview {
                     <meta http-equiv='Content-Security-Policy' content="default-src 'none'; font-src ${cspSrc}; style-src ${cspSrc} 'unsafe-inline'; script-src ${cspSrc};">
                     <script type='module' src='${mainUri}'></script>
                     <link href="${codiconsUri}" rel="stylesheet" />
+                    <link href="${memoryInspectorCSS}" rel="stylesheet" />
                 </head>
                 <body>
                     <div id='root'></div>

--- a/src/webview/components/memory-table.tsx
+++ b/src/webview/components/memory-table.tsx
@@ -31,7 +31,6 @@ export interface MoreMemorySelectProps {
     options: number[];
     direction: 'above' | 'below';
     fetchMemory(partialOptions?: Partial<DebugProtocol.ReadMemoryArguments>): Promise<void>;
-
 }
 
 export const MoreMemorySelect: React.FC<MoreMemorySelectProps> = ({ count, offset, options, fetchMemory, direction }) => {
@@ -50,10 +49,8 @@ export const MoreMemorySelect: React.FC<MoreMemorySelectProps> = ({ count, offse
             let newCount = count;
             if (direction === 'above') {
                 newOffset = offset - numBytes;
-                newCount = count + numBytes;
-            } else {
-                newCount = count + numBytes;
             }
+            newCount = count + numBytes;
             fetchMemory({ offset: newOffset, count: newCount });
         }
     };
@@ -87,13 +84,13 @@ export const MoreMemorySelect: React.FC<MoreMemorySelectProps> = ({ count, offse
         </div>
     );
 };
+
 interface MemoryTableProps extends TableRenderOptions {
     memory?: Memory;
     decorations: Decoration[];
     offset: number;
     count: number;
     fetchMemory(partialOptions?: Partial<DebugProtocol.ReadMemoryArguments>): Promise<void>;
-
 }
 
 export class MemoryTable extends React.Component<MemoryTableProps> {

--- a/src/webview/components/memory-table.tsx
+++ b/src/webview/components/memory-table.tsx
@@ -30,11 +30,11 @@ export interface MoreMemorySelectProps {
     offset: number;
     options: number[];
     direction: 'above' | 'below';
-    updateMemoryArguments: (memoryArguments: Partial<DebugProtocol.ReadMemoryArguments>) => Promise<void>;
-    refreshMemory: () => void;
+    fetchMemory(partialOptions?: Partial<DebugProtocol.ReadMemoryArguments>): Promise<void>;
+
 }
 
-export const MoreMemorySelect: React.FC<MoreMemorySelectProps> = ({ count, offset, options, updateMemoryArguments, refreshMemory, direction }) => {
+export const MoreMemorySelect: React.FC<MoreMemorySelectProps> = ({ count, offset, options, fetchMemory, direction }) => {
     const [numBytes, setNumBytes] = React.useState<number>(options[0]);
     const containerRef = React.createRef<HTMLDivElement>();
     const onSelectChange = (e: React.ChangeEvent<HTMLSelectElement>): void => {
@@ -54,8 +54,7 @@ export const MoreMemorySelect: React.FC<MoreMemorySelectProps> = ({ count, offse
             } else {
                 newCount = count + numBytes;
             }
-            updateMemoryArguments({ offset: newOffset, count: newCount })
-                .then(refreshMemory);
+            fetchMemory({ offset: newOffset, count: newCount });
         }
     };
 
@@ -93,14 +92,14 @@ interface MemoryTableProps extends TableRenderOptions {
     decorations: Decoration[];
     offset: number;
     count: number;
-    updateMemoryArguments: (memoryArguments: Partial<DebugProtocol.ReadMemoryArguments>) => Promise<void>;
-    refreshMemory: () => void;
+    fetchMemory(partialOptions?: Partial<DebugProtocol.ReadMemoryArguments>): Promise<void>;
+
 }
 
 export class MemoryTable extends React.Component<MemoryTableProps> {
     public render(): React.ReactNode {
         const rows = this.getTableRows();
-        const { offset, count, updateMemoryArguments, memory, refreshMemory } = this.props;
+        const { offset, count, memory, fetchMemory } = this.props;
         const showMoreMemoryButton = !!memory?.bytes.length;
         return (
             <div>
@@ -119,8 +118,7 @@ export class MemoryTable extends React.Component<MemoryTableProps> {
                         count={count}
                         options={[128, 256, 512]}
                         direction='above'
-                        updateMemoryArguments={updateMemoryArguments}
-                        refreshMemory={refreshMemory}
+                        fetchMemory={fetchMemory}
                     />)}
                     {rows}
                     {showMoreMemoryButton && (<MoreMemorySelect
@@ -128,8 +126,7 @@ export class MemoryTable extends React.Component<MemoryTableProps> {
                         count={count}
                         options={[128, 256, 512]}
                         direction='below'
-                        updateMemoryArguments={updateMemoryArguments}
-                        refreshMemory={refreshMemory}
+                        fetchMemory={fetchMemory}
                     />)}
                 </VSCodeDataGrid>
             </div>

--- a/src/webview/components/memory-table.tsx
+++ b/src/webview/components/memory-table.tsx
@@ -20,7 +20,7 @@ import {
     VSCodeDataGridRow,
     VSCodeDataGridCell
 } from '@vscode/webview-ui-toolkit/react';
-import { Decoration, Memory, SerializedTableRenderOptions, StylableNodeAttributes, isTrigger } from '../utils/view-types';
+import { Decoration, Memory, StylableNodeAttributes, isTrigger } from '../utils/view-types';
 import { toHexStringWithRadixMarker } from '../../common/memory-range';
 import { TableRenderOptions } from '../columns/column-contribution-service';
 import { DebugProtocol } from '@vscode/debugprotocol';

--- a/src/webview/components/memory-widget.tsx
+++ b/src/webview/components/memory-widget.tsx
@@ -32,7 +32,6 @@ interface MemoryWidgetProps {
     updateMemoryArguments: (memoryArguments: Partial<DebugProtocol.ReadMemoryArguments>) => void;
     toggleColumn(id: string, active: boolean): void;
     fetchMemory(partialOptions?: Partial<DebugProtocol.ReadMemoryArguments>): Promise<void>
-
 }
 
 interface MemoryWidgetState {

--- a/src/webview/components/memory-widget.tsx
+++ b/src/webview/components/memory-widget.tsx
@@ -29,8 +29,10 @@ interface MemoryWidgetProps {
     offset: number;
     count: number;
     refreshMemory: () => void;
-    updateMemoryArguments: (memoryArguments: Partial<DebugProtocol.ReadMemoryArguments>) => Promise<void>;
+    updateMemoryArguments: (memoryArguments: Partial<DebugProtocol.ReadMemoryArguments>) => void;
     toggleColumn(id: string, active: boolean): void;
+    fetchMemory(partialOptions?: Partial<DebugProtocol.ReadMemoryArguments>): Promise<void>
+
 }
 
 interface MemoryWidgetState {
@@ -79,8 +81,7 @@ export class MemoryWidget extends React.Component<MemoryWidgetProps, MemoryWidge
                 groupsPerRow={this.state.groupsPerRow}
                 offset={this.props.offset}
                 count={this.props.count}
-                updateMemoryArguments={this.props.updateMemoryArguments}
-                refreshMemory={this.props.refreshMemory}
+                fetchMemory={this.props.fetchMemory}
             />
         </>;
     }

--- a/src/webview/components/memory-widget.tsx
+++ b/src/webview/components/memory-widget.tsx
@@ -29,7 +29,7 @@ interface MemoryWidgetProps {
     offset: number;
     count: number;
     refreshMemory: () => void;
-    updateMemoryArguments: (memoryArguments: Partial<DebugProtocol.ReadMemoryArguments>) => void;
+    updateMemoryArguments: (memoryArguments: Partial<DebugProtocol.ReadMemoryArguments>) => Promise<void>;
     toggleColumn(id: string, active: boolean): void;
 }
 
@@ -77,6 +77,10 @@ export class MemoryWidget extends React.Component<MemoryWidgetProps, MemoryWidge
                 wordSize={this.state.wordSize}
                 wordsPerGroup={this.state.bytesPerGroup}
                 groupsPerRow={this.state.groupsPerRow}
+                offset={this.props.offset}
+                count={this.props.count}
+                updateMemoryArguments={this.props.updateMemoryArguments}
+                refreshMemory={this.props.refreshMemory}
             />
         </>;
     }

--- a/src/webview/components/options-widget.tsx
+++ b/src/webview/components/options-widget.tsx
@@ -23,7 +23,7 @@ import { MultiSelectWithLabel } from './multi-select-bar';
 
 export interface OptionsWidgetProps extends TableRenderOptions, Required<DebugProtocol.ReadMemoryArguments> {
     updateRenderOptions: (options: Partial<SerializedTableRenderOptions>) => void;
-    updateMemoryArguments: (memoryArguments: Partial<DebugProtocol.ReadMemoryArguments>) => void;
+    updateMemoryArguments: (memoryArguments: Partial<DebugProtocol.ReadMemoryArguments>) => Promise<void>;
     refreshMemory: () => void;
     toggleColumn(id: string, active: boolean): void;
 }

--- a/src/webview/components/options-widget.tsx
+++ b/src/webview/components/options-widget.tsx
@@ -23,7 +23,7 @@ import { MultiSelectWithLabel } from './multi-select-bar';
 
 export interface OptionsWidgetProps extends TableRenderOptions, Required<DebugProtocol.ReadMemoryArguments> {
     updateRenderOptions: (options: Partial<SerializedTableRenderOptions>) => void;
-    updateMemoryArguments: (memoryArguments: Partial<DebugProtocol.ReadMemoryArguments>) => Promise<void>;
+    updateMemoryArguments: (memoryArguments: Partial<DebugProtocol.ReadMemoryArguments>) => void;
     refreshMemory: () => void;
     toggleColumn(id: string, active: boolean): void;
 }

--- a/src/webview/memory-webview-view.tsx
+++ b/src/webview/memory-webview-view.tsx
@@ -77,7 +77,9 @@ class App extends React.Component<{}, MemoryAppState> {
         />;
     }
 
-    protected updateMemoryState = (newState: Partial<MemoryState>) => this.setState(prevState => ({ ...prevState, ...newState }));
+    protected updateMemoryState = (newState: Partial<MemoryState>): Promise<void> => new Promise(resolve => {
+        this.setState(prevState => ({ ...prevState, ...newState }), resolve);
+    });
 
     protected async setOptions(options?: Partial<DebugProtocol.ReadMemoryArguments>): Promise<void> {
         messenger.sendRequest(logMessageType, HOST_EXTENSION, `Setting options: ${JSON.stringify(options)}`);

--- a/src/webview/utils/view-types.ts
+++ b/src/webview/utils/view-types.ts
@@ -72,3 +72,9 @@ export interface StylableNodeAttributes {
 export interface FullNodeAttributes extends StylableNodeAttributes {
     content: string;
 }
+
+export type ReactInteraction<E extends Element = Element> = React.MouseEvent<E> | React.KeyboardEvent<E>;
+
+export function isTrigger(event: ReactInteraction): boolean {
+    return !('code' in event) || event.code === 'Enter' || event.code === 'Space';
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/blob/main/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

This MR address #17 by adding buttons to load more memory above/below the current memory table, similar to the implementation the Theia's memory-inspector

![morememory](https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/assets/62660714/d5b0efba-fe4d-4fd2-9c1a-9151beba4f0e)

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
- Start a debug session and hit a breakpoint
- Open the memory inspector by right-clicking on a variable
- Once the memory table loads observe that there are links to load memory above/below
- Try loading memory using the various options and observe that the Offset&Length fields update accordingly



#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
