### PR TITLE
Move css to external stylesheet

### DIFF
--- a/media/memory-inspector.css
+++ b/media/memory-inspector.css
@@ -15,51 +15,105 @@
  ********************************************************************************/
 
 
- .bytes-select {
-    color: var(--vscode-dropdown-forground);
-    border-radius: 2px;
-    font-size: var(--vscode-font-size);
-    border: 1px solid var(--vscode-dropdown-border);
-    background: var(--vscode-dropdown-background);
-    outline: none;
-    cursor: pointer;
-    padding-top: 3px;
-  }
+.bytes-select {
+  color: var(--vscode-dropdown-forground);
+  border-radius: 2px;
+  font-size: var(--vscode-font-size);
+  border: 1px solid var(--vscode-dropdown-border);
+  background: var(--vscode-dropdown-background);
+  outline: none;
+  cursor: pointer;
+  padding-top: 3px;
+}
 
- .more-memory-select {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    font-style: italic;
-    cursor: pointer;
-  }
-  
-  .more-memory-select-top {
-    display: flex;
-    justify-content: center;
-    height: 16px;
-    padding-bottom: 1px;
-    transition: border-color 0.1s;
-    border-color: transparent;
-  }
-  
-  .more-memory-select-top:hover {
-    border-bottom: 1px solid;
-    padding-bottom: 0;
-    border-color: var(--vscode-sideBar-foreground);
-  }
-  
-  .more-memory-select select {
-    border: none;
-    background: none;
-    border-radius: 3px;
-    margin: 0 2px;
-    position: relative;
-    bottom: 1px;
-    transition: background 0.1s;
-    font-style: italic;
-  }
-  
-  .more-memory-select select:hover {
-    background: var(--vscode-dropdown-background);
-  }
+.more-memory-select {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-style: italic;
+  cursor: pointer;
+}
+
+.more-memory-select-top {
+  display: flex;
+  justify-content: center;
+  height: 16px;
+  padding-bottom: 1px;
+  transition: border-color 0.1s;
+  border-color: transparent;
+}
+
+.more-memory-select-top:hover {
+  border-bottom: 1px solid;
+  padding-bottom: 0;
+  border-color: var(--vscode-sideBar-foreground);
+}
+
+.more-memory-select select {
+  border: none;
+  background: none;
+  border-radius: 3px;
+  margin: 0 2px;
+  position: relative;
+  bottom: 1px;
+  transition: background 0.1s;
+  font-style: italic;
+}
+
+.more-memory-select select:hover {
+  background: var(--vscode-dropdown-background);
+}
+
+.multi-select-bar {
+  display: flex;
+  flex: row nowrap;
+  box-sizing: border-box;
+  user-select: none;
+  -moz-user-select: none;
+  -webkit-user-select: none;
+}
+
+.multi-select-checkbox-wrapper {
+  display: flex;
+  position: relative;
+  flex: auto;
+  text-align: center;
+}
+
+.multi-select-label {
+  height: 100%;
+  flex: auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid;
+  padding: 0 6;
+  background-color: var(--vscode-editor-background);
+  border-color: var(--vscode-dropdown-border);
+  box-sizing: border-box;
+  text-transform: uppercase;
+}
+
+.multi-select-label.active {
+  background-color: var(--vscode-input-background);
+  border-color: var(--vscode-sideBar-foreground);
+  text-decoration: underline;
+  font-weight: bold;
+}
+
+.multi-select-label.inactive {
+  font-style: italic;
+  opacity: 0.7;
+}
+
+.multi-select-checkbox {
+  appearance: none;
+  -moz-appearance: none;
+  position: absolute;
+  left: 0;
+  top: 0;
+  margin: 0;
+  height: 100%;
+  width: 100%;
+  cursor: pointer;
+}

--- a/media/memory-inspector.css
+++ b/media/memory-inspector.css
@@ -66,7 +66,7 @@
 
 .multi-select-bar {
   display: flex;
-  flex: row nowrap;
+  flex-flow: row nowrap;
   box-sizing: border-box;
   user-select: none;
   -moz-user-select: none;
@@ -116,4 +116,39 @@
   height: 100%;
   width: 100%;
   cursor: pointer;
+}
+
+.options-widget-title {
+  display: flex;
+  flex-flow: row nowrap;
+  justify-content: space-between;
+}
+
+.advanced-options-toggle {
+  cursor: pointer;
+  display: flex;
+  flex-flow: row nowrap;
+  align-items: center;
+}
+
+.core-options {
+  display: grid;
+  column-gap: 6px;
+  grid-template-columns: 4fr 4fr 2fr 1fr;
+  margin: 6px 0;
+}
+
+.go-button {
+  /* Match height of inputs */
+  height: calc(var(--input-height) * 1px);
+  align-self: end;
+}
+
+.advanced-options {
+  display: grid;
+  column-gap: 6px;
+  row-gap: 3px;
+  grid-template-columns: max-content 1fr;
+  align-items: center;
+  margin: 6px 0;
 }

--- a/media/memory-inspector.css
+++ b/media/memory-inspector.css
@@ -64,6 +64,10 @@
   background: var(--vscode-dropdown-background);
 }
 
+.memory-options-widget {
+  margin-bottom: 8px;
+}
+
 .multi-select-bar {
   display: flex;
   flex-flow: row nowrap;
@@ -129,6 +133,10 @@
   display: flex;
   flex-flow: row nowrap;
   align-items: center;
+}
+
+.advanced-options-toggle i.codicon {
+  padding-right: 3px;
 }
 
 .core-options {

--- a/src/webview/components/multi-select-bar.tsx
+++ b/src/webview/components/multi-select-bar.tsx
@@ -16,63 +16,6 @@
 
 import * as React from 'react';
 
-export const MultiSelectBarStyle: React.CSSProperties = {
-    display: 'flex',
-    flexFlow: 'row nowrap',
-    userSelect: 'none',
-    boxSizing: 'border-box',
-    msUserSelect: 'none',
-    MozUserSelect: 'none',
-    WebkitUserSelect: 'none',
-};
-
-export const MultiSelectCheckboxWrapperStyle: React.CSSProperties = {
-    display: 'flex',
-    position: 'relative',
-    flex: 'auto',
-    textAlign: 'center',
-};
-
-export const MultiSelectLabelStyle: React.CSSProperties = {
-    height: '100%',
-    flex: 'auto',
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    border: '1px solid',
-    padding: '0 6',
-    backgroundColor: 'var(--vscode-editor-background)',
-    borderColor: 'var(--vscode-dropdown-border)',
-    boxSizing: 'border-box',
-    textTransform: 'uppercase',
-};
-
-export const MultiSelectActiveLabelStyle: React.CSSProperties = {
-    ...MultiSelectLabelStyle,
-    backgroundColor: 'var(--vscode-input-background)',
-    borderColor: 'var(--vscode-sideBar-foreground)',
-    textDecoration: 'underline',
-    fontWeight: 'bold',
-};
-
-export const MultiSelectInactiveLabelStyle: React.CSSProperties = {
-    ...MultiSelectActiveLabelStyle,
-    fontStyle: 'italic',
-    opacity: '0.7',
-};
-
-export const MultiSelectCheckboxStyle: React.CSSProperties = {
-    appearance: 'none',
-    WebkitAppearance: 'none',
-    position: 'absolute',
-    left: '0',
-    top: '0',
-    margin: '0',
-    height: '100%',
-    width: '100%',
-    cursor: 'pointer',
-};
-
 export interface SingleSelectItemProps {
     id: string;
     label: string;
@@ -91,7 +34,7 @@ export const MultiSelectBar: React.FC<MultiSelectBarProps> = ({ items, onSelecti
     }, [onSelectionChanged]);
 
     return (
-        <div className='multi-select-bar' id={id} style={MultiSelectBarStyle}>
+        <div className='multi-select-bar' id={id}>
             {items.map(({ label, id: itemId, checked }) => (<LabeledCheckbox
                 label={label}
                 onChange={changeHandler}
@@ -118,17 +61,19 @@ export const Label: React.FC<LabelProps> = ({ id, label, disabled, classNames, s
 };
 
 const LabeledCheckbox: React.FC<LabeledCheckboxProps> = ({ checked, label, onChange, id }) => (
-    <div className='multi-select-checkbox-wrapper' style={MultiSelectCheckboxWrapperStyle}>
+    <div className='multi-select-checkbox-wrapper' >
         <input
             tabIndex={0}
             type='checkbox'
             id={id}
             className='multi-select-checkbox'
-            style={MultiSelectCheckboxStyle}
             checked={checked}
             onChange={onChange}
         />
-        <Label id={id} label={label} classNames={['multi-select-label']} style={checked ? MultiSelectActiveLabelStyle : MultiSelectLabelStyle} />
+        <Label
+            id={id}
+            label={label}
+            classNames={['multi-select-label', checked ? 'active' : 'inactive']} />
     </div>
 );
 

--- a/src/webview/components/options-widget.tsx
+++ b/src/webview/components/options-widget.tsx
@@ -40,40 +40,6 @@ const enum InputId {
     GroupsPerRow = 'groups-per-row',
 }
 
-const TitleBarStyle: React.CSSProperties = {
-    display: 'flex',
-    flexFlow: 'row nowrap',
-    justifyContent: 'space-between',
-};
-
-const RenderOptionsToggleStyle: React.CSSProperties = {
-    cursor: 'pointer',
-    display: 'flex',
-    flexFlow: 'row nowrap',
-    alignItems: 'center',
-};
-
-const CoreOptionsStyle: React.CSSProperties = {
-    display: 'grid',
-    columnGap: '6px',
-    gridTemplateColumns: '4fr 4fr 2fr 1fr',
-    margin: '6px 0'
-};
-
-const GoButtonStyle: React.CSSProperties = {
-    height: 'calc(var(--input-height) * 1px)', // Match height of inputs;
-    alignSelf: 'end',
-};
-
-const AdvancedOptionsStyle: React.CSSProperties = {
-    display: 'grid',
-    columnGap: '6px',
-    rowGap: '3px',
-    gridTemplateColumns: 'max-content 1fr',
-    alignItems: 'center',
-    margin: '6px 0',
-};
-
 export class OptionsWidget extends React.Component<OptionsWidgetProps, OptionsWidgetState> {
     constructor(props: OptionsWidgetProps) {
         super(props);
@@ -82,23 +48,23 @@ export class OptionsWidget extends React.Component<OptionsWidgetProps, OptionsWi
 
     override render(): React.ReactNode {
         return <div className='memory-options-widget' style={{ marginBottom: '8px' }}>
-            <div className="options-widget-title" style={TitleBarStyle}>
+            <div className="options-widget-title">
                 <div className="title"></div>
-                <div className="advanced-options-toggle" role='button' tabIndex={0} onClick={this.toggleRenderOptions} style={RenderOptionsToggleStyle}>
+                <div className="advanced-options-toggle" role='button' tabIndex={0} onClick={this.toggleRenderOptions} >
                     <i className="codicon codicon-gear" style={{ paddingRight: '3px' }} />
                     {this.state.showRenderOptions ? 'Hide Settings' : 'Show Settings'}
                 </div>
             </div>
-            <div className="core-options" style={CoreOptionsStyle}>
+            <div className="core-options" >
                 <VSCodeTextField id={InputId.Address} onChange={this.handleInputChange} value={this.props.memoryReference}>Address</VSCodeTextField>
                 <VSCodeTextField id={InputId.Offset} onChange={this.handleInputChange} value={this.props.offset.toString()}>Offset</VSCodeTextField>
                 <VSCodeTextField id={InputId.Length} onChange={this.handleInputChange} value={this.props.count.toString()}>Length</VSCodeTextField>
-                <VSCodeButton onClick={this.props.refreshMemory} style={GoButtonStyle}>Go</VSCodeButton>
+                <VSCodeButton className='go-button' onClick={this.props.refreshMemory} >Go</VSCodeButton>
             </div>
             {
                 this.state.showRenderOptions && <>
                     <VSCodeDivider />
-                    <div className="advanced-options" style={AdvancedOptionsStyle}>
+                    <div className="advanced-options">
                         <label htmlFor={InputId.BytesPerGroup}>Bytes per Group</label>
                         <VSCodeDropdown id={InputId.BytesPerGroup} onChange={this.handleInputChange} value={this.props.wordsPerGroup.toString()}>
                             <VSCodeOption>1</VSCodeOption>

--- a/src/webview/components/options-widget.tsx
+++ b/src/webview/components/options-widget.tsx
@@ -47,11 +47,11 @@ export class OptionsWidget extends React.Component<OptionsWidgetProps, OptionsWi
     }
 
     override render(): React.ReactNode {
-        return <div className='memory-options-widget' style={{ marginBottom: '8px' }}>
+        return <div className='memory-options-widget' >
             <div className="options-widget-title">
                 <div className="title"></div>
                 <div className="advanced-options-toggle" role='button' tabIndex={0} onClick={this.toggleRenderOptions} >
-                    <i className="codicon codicon-gear" style={{ paddingRight: '3px' }} />
+                    <i className="codicon codicon-gear" />
                     {this.state.showRenderOptions ? 'Hide Settings' : 'Show Settings'}
                 </div>
             </div>


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Addresses #35 by moving all CSS in JS to an external stylesheet asset

Contributors guide: https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/blob/main/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
- Run a debug session, open the memory inspector
- Observe there are no stylistic regressions in the memory table + options widget

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
