### PR TITLE
Add codicons in vsix package

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -4,3 +4,5 @@ src
 *.vsix
 dist/**/*.js.map
 node_modules
+!node_modules/@vscode/codicons/dist/codicon.css
+!node_modules/@vscode/codicons/dist/codicon.ttf


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.
Contributors guide: https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/blob/main/CONTRIBUTING.md
-->

Fix for https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/issues/45 . Codicons are not included in packaged extension so they can't be displayed when extension is installed from vsix (for example from the marketplace).

Similar issue is described here: https://github.com/microsoft/vscode-extension-samples/issues/692

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

- Do not ignore codicons when packaging extension

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Do not test it in development. Instead select a .vsix generated as part of github actions CI. Check that advanced settings icon is visible.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
