### PR TITLE
Don't fetch variables if nothing to fetch

### DIFF
--- a/src/webview/variables/variable-decorations.ts
+++ b/src/webview/variables/variable-decorations.ts
@@ -46,7 +46,7 @@ export class VariableDecorator implements ColumnContribution, Decorator {
     get onDidChange(): IEvent<Decoration[]> { return this.onDidChangeEmitter.event; }
 
     async fetchData(currentViewParameters: DebugProtocol.ReadMemoryArguments): Promise<void> {
-        if (!this.active) { return; }
+        if (!this.active || !currentViewParameters.memoryReference || !currentViewParameters.count) { return; }
         const visibleVariables = (await messenger.sendRequest(getVariables, HOST_EXTENSION, currentViewParameters))
             .map<BigIntVariableRange>(transmissible => {
                 const startAddress = BigInt(transmissible.startAddress);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/blob/main/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
When the variables column is open by default, it will immediately make a request for data before the view knows what its actual input parameters are. This PR makes it skip any request that appears meaningless: no `memoryReference` or `count=0`

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
