### PR TITLE
Show variable on first mention in display

### DIFF
--- a/src/webview/variables/variable-decorations.ts
+++ b/src/webview/variables/variable-decorations.ts
@@ -23,7 +23,7 @@ import { EventEmitter, IEvent } from '../utils/events';
 import { ColumnContribution } from '../columns/column-contribution-service';
 import { Decorator } from '../decorations/decoration-service';
 import { ReactNode } from 'react';
-import { areVariablesEqual, compareBigInt, isWithin, BigIntMemoryRange, BigIntVariableRange } from '../../common/memory-range';
+import { areVariablesEqual, compareBigInt, BigIntMemoryRange, BigIntVariableRange, doOverlap } from '../../common/memory-range';
 import * as React from 'react';
 
 const NON_HC_COLORS = [
@@ -82,9 +82,9 @@ export class VariableDecorator implements ColumnContribution, Decorator {
         }, []);
     }
 
-    /** Returns variables that start in the given range. */
     protected lastCall?: bigint;
     protected currentIndex = 0;
+    /** Returns variables that start in the given range. */
     protected getVariablesInRange(range: BigIntMemoryRange): Array<{ variable: BigIntVariableRange, color: string }> | undefined {
         if (!this.currentVariables?.length) { return undefined; }
         if (this.currentIndex === this.currentVariables.length - 1 && this.currentVariables[this.currentIndex].startAddress < range.startAddress) { return undefined; }
@@ -92,7 +92,7 @@ export class VariableDecorator implements ColumnContribution, Decorator {
         this.lastCall = range.startAddress;
         const result = [];
         while (this.currentIndex < this.currentVariables.length && this.currentVariables[this.currentIndex].startAddress < range.endAddress) {
-            if (isWithin(this.currentVariables[this.currentIndex].startAddress, range)) {
+            if (doOverlap(this.currentVariables[this.currentIndex], range)) {
                 result.push({ color: NON_HC_COLORS[this.currentIndex % 5], variable: this.currentVariables[this.currentIndex] });
             }
             this.currentIndex++;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/blob/main/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes an issue where a variable's name would not be shown if it started before the current display start.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Load some memory that includes a variable with a large memory footprint.
2. Set the display parameters such that the variable starts before the initial address but continues into the frame.
3. The variable's name should still be displayed.
4. All variable's names should be displayed exactly once.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
