### PR TITLE
Introduce Auto-Append scrolling behavior and rename Infinite behavior to Grow

### DIFF
--- a/media/options-widget.css
+++ b/media/options-widget.css
@@ -74,6 +74,11 @@
   row-gap: 12px;
 }
 
+.form-textfield {
+  position: relative;
+  padding-bottom: 16px;
+}
+
 .form-textfield > input {
   width: 150px;
 }
@@ -87,6 +92,12 @@
   height: calc(var(--input-minHeight) * 1px);
   margin-top: 1rem;
   align-self: start;
+}
+
+.form-options-memory-read-argument-hint {
+  position: absolute;
+  bottom: 0;
+  color: var(--vscode-descriptionForeground);
 }
 
 .advanced-options-content h2 {

--- a/package.json
+++ b/package.json
@@ -214,12 +214,14 @@
           "type": "string",
           "enum": [
             "Paginate",
-            "Infinite"
+            "Grow",
+            "Auto-Append"
           ],
           "default": "Paginate",
           "enumDescriptions": [
             "Maintains a consistent memory size, replacing the previous request.",
-            "Appends new memory to bounds of current request, resulting in a growing list."
+            "Appends new memory to bounds of current request, resulting in a growing list.",
+            "Automatically appends new memory to the bounds of the current request on reaching the end of the list, resulting in a growing list."
           ],
           "description": "Behavior when adding more memory beyond the current view."
         },

--- a/src/webview/components/memory-widget.tsx
+++ b/src/webview/components/memory-widget.tsx
@@ -17,22 +17,20 @@
 import { DebugProtocol } from '@vscode/debugprotocol';
 import React from 'react';
 import { ColumnStatus } from '../columns/column-contribution-service';
-import { Decoration, Endianness, Memory, MemoryDisplayConfiguration } from '../utils/view-types';
+import { Decoration, Endianness, Memory, MemoryDisplayConfiguration, MemoryState } from '../utils/view-types';
 import { MemoryTable } from './memory-table';
 import { OptionsWidget } from './options-widget';
 
 interface MemoryWidgetProps extends MemoryDisplayConfiguration {
+    configuredReadArguments: Required<DebugProtocol.ReadMemoryArguments>;
+    activeReadArguments: Required<DebugProtocol.ReadMemoryArguments>;
     memory?: Memory;
     title: string;
     decorations: Decoration[];
     columns: ColumnStatus[];
-    memoryReference: string;
-    offset: number;
-    count: number;
     effectiveAddressLength: number;
     isMemoryFetching: boolean;
-    refreshMemory: () => void;
-    updateMemoryArguments: (memoryArguments: Partial<DebugProtocol.ReadMemoryArguments>) => void;
+    updateMemoryState: (state: Partial<MemoryState>) => void;
     toggleColumn(id: string, active: boolean): void;
     isFrozen: boolean;
     toggleFrozen: () => void;
@@ -62,25 +60,26 @@ export class MemoryWidget extends React.Component<MemoryWidgetProps, MemoryWidge
                 title={this.props.title}
                 updateTitle={this.props.updateTitle}
                 columnOptions={this.props.columns}
-                memoryReference={this.props.memoryReference}
-                offset={this.props.offset}
-                count={this.props.count}
+                configuredReadArguments={this.props.configuredReadArguments}
+                activeReadArguments={this.props.activeReadArguments}
                 endianness={this.state.endianness}
                 bytesPerWord={this.props.bytesPerWord}
                 wordsPerGroup={this.props.wordsPerGroup}
                 groupsPerRow={this.props.groupsPerRow}
-                updateMemoryArguments={this.props.updateMemoryArguments}
+                updateMemoryState={this.props.updateMemoryState}
                 updateRenderOptions={this.props.updateMemoryDisplayConfiguration}
                 resetRenderOptions={this.props.resetMemoryDisplayConfiguration}
-                refreshMemory={this.props.refreshMemory}
                 addressPadding={this.props.addressPadding}
                 addressRadix={this.props.addressRadix}
                 showRadixPrefix={this.props.showRadixPrefix}
+                fetchMemory={this.props.fetchMemory}
                 toggleColumn={this.props.toggleColumn}
                 toggleFrozen={this.props.toggleFrozen}
                 isFrozen={this.props.isFrozen}
             />
             <MemoryTable
+                configuredReadArguments={this.props.configuredReadArguments}
+                activeReadArguments={this.props.activeReadArguments}
                 decorations={this.props.decorations}
                 columnOptions={this.props.columns.filter(candidate => candidate.active)}
                 memory={this.props.memory}
@@ -88,8 +87,6 @@ export class MemoryWidget extends React.Component<MemoryWidgetProps, MemoryWidge
                 bytesPerWord={this.props.bytesPerWord}
                 wordsPerGroup={this.props.wordsPerGroup}
                 groupsPerRow={this.props.groupsPerRow}
-                offset={this.props.offset}
-                count={this.props.count}
                 effectiveAddressLength={this.props.effectiveAddressLength}
                 fetchMemory={this.props.fetchMemory}
                 isMemoryFetching={this.props.isMemoryFetching}

--- a/src/webview/utils/view-types.ts
+++ b/src/webview/utils/view-types.ts
@@ -54,7 +54,15 @@ export function areDecorationsEqual(one: Decoration, other: Decoration): boolean
     return areRangesEqual(one.range, other.range) && deepequal(one.style, other.style);
 }
 
-export interface MemoryState extends DebugProtocol.ReadMemoryArguments {
+export interface MemoryState {
+    /**
+     * The user configured memory read arguments
+     */
+    configuredReadArguments: Required<DebugProtocol.ReadMemoryArguments>;
+    /**
+     * The active memory read arguments used to load the memory
+     */
+    activeReadArguments: Required<DebugProtocol.ReadMemoryArguments>;
     memory?: Memory;
     isMemoryFetching: boolean;
 }
@@ -88,7 +96,7 @@ export interface MemoryDisplayConfiguration {
     addressRadix: Radix;
     showRadixPrefix: boolean;
 }
-export type ScrollingBehavior = 'Paginate' | 'Infinite';
+export type ScrollingBehavior = 'Paginate' | 'Grow' | 'Auto-Append';
 
 export type AddressPadding = 'Min' | number;
 export const AddressPaddingOptions = {

--- a/src/webview/variables/variable-decorations.ts
+++ b/src/webview/variables/variable-decorations.ts
@@ -66,7 +66,7 @@ export class VariableDecorator implements ColumnContribution, Decorator {
     async activate(memory: MemoryState): Promise<void> {
         this.active = true;
         if (memory.memory?.bytes.length) {
-            await this.fetchData({ count: memory.count, offset: memory.offset, memoryReference: memory.memoryReference, });
+            await this.fetchData(memory.activeReadArguments);
         }
     }
 


### PR DESCRIPTION
#### What it does

Introduces the `Auto-Append` scrolling behavior and renames the `Infinite` scroll behavior to `Grow`.

![image](https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/assets/13104167/f912aff4-b68c-4c3e-87e3-e3831c201954)It also separates the user arguments from the actual memory read arguments:

> The growing memory content buffer would be cleared by a subsequent click on the Go button. #56 

When the user provided arguments are the same then we have the following view:

![image](https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/assets/13104167/b5eb6bc0-80eb-41b3-8c64-5b770df4c4e6)

If the user navigates within the table:

![image](https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/assets/13104167/c26cb2bd-ce8c-4deb-a48b-29a34c53f307)

-- 

![image](https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/assets/13104167/9fd9aee8-2e76-4619-939f-8cd3d617fbfe)

#### How to test

1. Switch to `auto-append` scrolling behavior in the settings
1. Scroll to the bottom
  - New data will be appended to the bottom and you can scroll again
  - The options will be updated with a new label (see description above)

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Closes #56 
