### PR TITLE
Fix state mismatch in initially visible columns

### DIFF
--- a/src/webview/columns/column-contribution-service.ts
+++ b/src/webview/columns/column-contribution-service.ts
@@ -66,12 +66,10 @@ class ColumnContributionService {
             }
         };
     }
-    async show(id: string, memoryState?: MemoryState): Promise<ColumnStatus[]> {
+    async show(id: string, memoryState: MemoryState): Promise<ColumnStatus[]> {
         const wrapper = this.registeredColumns.get(id);
         if (wrapper) {
-            if (memoryState) {
-                await wrapper.contribution.activate?.(memoryState);
-            }
+            await wrapper.contribution.activate?.(memoryState);
             wrapper.active = true;
         }
         return this.columnArray.slice();

--- a/src/webview/memory-webview-view.tsx
+++ b/src/webview/memory-webview-view.tsx
@@ -76,9 +76,9 @@ class App extends React.Component<{}, MemoryAppState> {
             for (const column of columnContributionService.getColumns()) {
                 const id = column.contribution.id;
                 const configurable = column.configurable;
-                this.setColumnVisibility(id, !configurable || !!config.visibleColumns?.includes(id));
+                this.toggleColumn(id, !configurable || !!config.visibleColumns?.includes(id));
             }
-            this.setState({ ...(config as MemoryDisplayConfiguration) });
+            this.setState(prevState => ({ ...prevState, ...(config as MemoryDisplayConfiguration) }));
         });
         messenger.sendNotification(readyType, HOST_EXTENSION, undefined);
     }
@@ -158,19 +158,10 @@ class App extends React.Component<{}, MemoryAppState> {
     }
 
     protected toggleColumn = (id: string, active: boolean): void => { this.doToggleColumn(id, active); };
-    protected doToggleColumn(id: string, isVisible: boolean): void {
-        this.setColumnVisibility(id, isVisible);
-        this.setState({ columns: columnContributionService.getColumns() });
+    protected async doToggleColumn(id: string, isVisible: boolean): Promise<void> {
+        const columns = isVisible ? await columnContributionService.show(id, this.state) : columnContributionService.hide(id);
+        this.setState(prevState => ({ ...prevState, columns }));
     }
-
-    protected setColumnVisibility(columnId: string, isVisible: boolean): void {
-        if (isVisible) {
-            columnContributionService.show(columnId);
-        } else {
-            columnContributionService.hide(columnId);
-        }
-    }
-
 }
 
 const container = document.getElementById('root') as Element;

--- a/src/webview/variables/variable-decorations.ts
+++ b/src/webview/variables/variable-decorations.ts
@@ -65,7 +65,9 @@ export class VariableDecorator implements ColumnContribution, Decorator {
 
     async activate(memory: MemoryState): Promise<void> {
         this.active = true;
-        await this.fetchData({ count: memory.count, offset: memory.offset, memoryReference: memory.memoryReference });
+        if (memory.memory?.bytes.length) {
+            await this.fetchData({ count: memory.count, offset: memory.offset, memoryReference: memory.memoryReference, });
+        }
     }
 
     deactivate(): void {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/blob/main/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

After https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/pull/64, the variables column was broken if initially visible. That was due to the fact that the contribution's `activate` method was never called, so it was never considered active. This PR restores the behavior where `activate` is called unconditionally and the current memory state (which may be no memory) is always passed in.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Set the `variables` column to be visible initially in preferences.
2. Use the `View in Memory Inspector` command on a variable in a debug session.
3. The `variables` column should appear and should be populated.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
