### PR TITLE
Small CSS readability improvements

### DIFF
--- a/media/memory-table.css
+++ b/media/memory-table.css
@@ -14,10 +14,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-.memory-inspector-table .group-separator > td {
-  border-bottom: 2px solid var(--vscode-editor-lineHighlightBorder);
-}
-
 .memory-inspector-table tr > th:not(.fit),
 .memory-inspector-table tr > td:not(.fit) {
   min-width: 120px;

--- a/media/theme/components/table.css
+++ b/media/theme/components/table.css
@@ -37,6 +37,12 @@
   background: var(--vscode-editor-background);
   transition: box-shadow 0.2s;
 }
+.p-datatable .p-datatable-tbody > tr:nth-child(odd) {
+  background: var(--vscode-tree-tableOddRowsBackground);
+}
+.p-datatable .p-datatable-tbody > tr:nth-child(4n) > td {
+  border-bottom: 2px solid var(--vscode-editor-lineHighlightBorder);
+}
 .p-datatable .p-datatable-tbody > tr:hover {
   background: var(--vscode-settings-rowHoverBackground);
 }
@@ -44,14 +50,16 @@
   vertical-align: top;
   text-align: left;
   padding: 4px 12px;
-  word-break: break-all;
-  overflow-wrap: anywhere;
+  word-break: break-word;
+  overflow-wrap: break-word;
   white-space: unset;
 }
 .p-datatable .p-datatable-tbody > tr > td.fit {
   width: 1%;
   word-wrap: break-word;
   word-break: unset;
+  background: var(--vscode-debugView-stateLabelBackground);
+  color: var(--vscode-debugView-stateLabelForeground);
 }
 .p-datatable .p-datatable-thead > tr > th.fit {
   min-width: 80px;

--- a/src/webview/components/memory-table.tsx
+++ b/src/webview/components/memory-table.tsx
@@ -17,7 +17,7 @@
 import { DebugProtocol } from '@vscode/debugprotocol';
 import memoize from 'memoize-one';
 import { Column } from 'primereact/column';
-import { DataTable, DataTableCellSelection, DataTableProps, DataTableRowData, DataTableSelectionCellChangeEvent } from 'primereact/datatable';
+import { DataTable, DataTableCellSelection, DataTableProps, DataTableSelectionCellChangeEvent } from 'primereact/datatable';
 import { ProgressSpinner } from 'primereact/progressspinner';
 import React from 'react';
 import { TableRenderOptions } from '../columns/column-contribution-service';
@@ -211,7 +211,6 @@ export class MemoryTable extends React.PureComponent<MemoryTableProps, MemoryTab
             lazy: true,
             metaKeySelection: false,
             onSelectionChange: this.onSelectionChanged,
-            rowClassName: this.rowClass,
             resizableColumns: true,
             scrollable: true,
             scrollHeight: 'flex',
@@ -286,20 +285,6 @@ export class MemoryTable extends React.PureComponent<MemoryTableProps, MemoryTab
         );
     }
 
-    protected rowClass = (data?: DataTableRowData<MemoryRowData[]>) => {
-        const css: string[] = [];
-
-        if (data !== undefined && this.isGroupSeparatorRow(data)) {
-            css.push(MemoryTable.GROUP_SEPARATOR);
-        }
-
-        return css;
-    };
-
-    protected isGroupSeparatorRow(row: MemoryRowData): boolean {
-        return row.rowIndex % 4 === 3;
-    }
-
     protected createTableRows = memoize((memory: Memory, options: MemoryRowListOptions): MemoryRowData[] => {
         const rows: MemoryRowData[] = [];
         for (let i = 0; i < options.numRows; i++) {
@@ -333,5 +318,4 @@ export class MemoryTable extends React.PureComponent<MemoryTableProps, MemoryTab
 
 export namespace MemoryTable {
     export const TABLE_CLASS = 'memory-inspector-table';
-    export const GROUP_SEPARATOR = 'group-separator';
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/blob/main/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The recent switch to primereact introduced some UX deficiencies that this PR is intended to improve.

1. Presently, the Address column is set to be as narrow as it can be while containing its content, while the other columns equally take up the rest of the available width, giving the appearance of inconsistent or broken formatting. -- This PR clarifies the intent by visually distinguishing the Address column with VSCode's theme variables for preformatted text.
2. Presently, each table cell is set to wrap text between any two characters. The result is especially awkward when there are multiple variables listed in the same table cell. -- This PR modifies the text wrap CSS rules to prefer breaking on whitespace when there is whitespace.
3. Presently, table rows may include a lot of white space due to distributing the available width, make it visually tricky to track left and right and be sure you're looking at the same line. -- This PR adds a common pattern of subtly altering the coloring of every other row. Similarly, it removes the JS handling of the horizontal divider every 4th row in favor of plain CSS.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

0. Build the branch. Run a debug. Open the Memory Inspector to view one or more variables.
1. Look over the Address column while switching between the default VSCode color themes, especially the High Contrast themes, as well as any other themes that interest you.
2. Adjust the memory contents so that multiple variables appear in the same table cell. Resize the window to observe the text wrapping behaviors, and look for variable names to stay on the same line when possible, but other fields to wrap between any characters.
3. Look over the row colors while switching between the default VSCode color themes, especially the High Contrast themes, as well as any other themes that interest you.

#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
