### PR TITLE
Introduce Autofit choice for groups per row

### DIFF
--- a/media/memory-table.css
+++ b/media/memory-table.css
@@ -23,6 +23,14 @@
   font-family: var(--vscode-editor-font-family);
 }
 
+.memory-inspector-table.groups-per-row-autofit tr > td.column-data > .data-groups-container {
+  overflow: hidden;
+  height: 1em;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+}
+
 /* == MoreMemorySelect == */
 
 .bytes-select {

--- a/media/memory-table.css
+++ b/media/memory-table.css
@@ -14,8 +14,8 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-.memory-inspector-table tr > th:not(.fit),
-.memory-inspector-table tr > td:not(.fit) {
+.memory-inspector-table tr > th:not(.content-width-fit),
+.memory-inspector-table tr > td:not(.content-width-fit) {
   min-width: 120px;
 }
 
@@ -72,10 +72,6 @@
 
 .more-memory-select select:hover:not(.p-disabled) {
   background: var(--vscode-dropdown-background);
-}
-
-.byte-group:not(:last-of-type) {
-  margin-right: 0.2em;
 }
 
 .radix-prefix {

--- a/media/theme/components/table.css
+++ b/media/theme/components/table.css
@@ -54,14 +54,14 @@
   overflow-wrap: break-word;
   white-space: unset;
 }
-.p-datatable .p-datatable-tbody > tr > td.fit {
+.p-datatable .p-datatable-tbody > tr > td.content-width-fit {
   width: 1%;
   word-wrap: break-word;
   word-break: unset;
   background: var(--vscode-debugView-stateLabelBackground);
   color: var(--vscode-debugView-stateLabelForeground);
 }
-.p-datatable .p-datatable-thead > tr > th.fit {
+.p-datatable .p-datatable-thead > tr > th.content-width-fit {
   min-width: 80px;
 }
 

--- a/package.json
+++ b/package.json
@@ -184,8 +184,9 @@
           "description": "Default words per group"
         },
         "memory-inspector.groupings.groupsPerRow": {
-          "type": "number",
+          "type": ["string", "number"],
           "enum": [
+            "Autofit",
             1,
             2,
             4,

--- a/src/common/typescript.ts
+++ b/src/common/typescript.ts
@@ -1,0 +1,23 @@
+/********************************************************************************
+ * Copyright (C) 2024 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+export type TypeOfArrayElement<T> = T extends readonly (infer E)[] ? E : never;
+
+export function tryToNumber(value?: string | number): number | undefined {
+    const asNumber = Number(value);
+    if (value === '' || isNaN(asNumber)) { return undefined; }
+    return asNumber;
+}

--- a/src/common/typescript.ts
+++ b/src/common/typescript.ts
@@ -14,8 +14,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-export type TypeOfArrayElement<T> = T extends readonly (infer E)[] ? E : never;
-
 export function tryToNumber(value?: string | number): number | undefined {
     const asNumber = Number(value);
     if (value === '' || isNaN(asNumber)) { return undefined; }

--- a/src/plugin/manifest.ts
+++ b/src/plugin/manifest.ts
@@ -30,20 +30,20 @@ export const DEFAULT_REFRESH_ON_STOP = 'on';
 // Words
 // - Bytes per Word
 export const CONFIG_BYTES_PER_WORD = 'groupings.bytesPerWord';
-export const CONFIG_BYTES_PER_WORD_CHOICES = [1, 2, 4, 8, 16];
+export const CONFIG_BYTES_PER_WORD_CHOICES = [1, 2, 4, 8, 16] as const;
 export const DEFAULT_BYTES_PER_WORD = 1;
 
 // - Words per Group
 export const CONFIG_WORDS_PER_GROUP = 'groupings.wordsPerGroup';
-export const CONFIG_WORDS_PER_GROUP_CHOICES = [1, 2, 4, 8, 16];
+export const CONFIG_WORDS_PER_GROUP_CHOICES = [1, 2, 4, 8, 16] as const;
 export const DEFAULT_WORDS_PER_GROUP = 1;
 
 // - Groups per Row
-export type GroupsPerRowChoices = ['Autofit', ...number[]];
 export const CONFIG_GROUPS_PER_ROW = 'groupings.groupsPerRow';
 export const CONFIG_GROUPS_PER_ROW_NUMERIC_CHOICES = [1, 2, 4, 8, 16, 32] as const;
-export const CONFIG_GROUPS_PER_ROW_CHOICES: GroupsPerRowChoices = ['Autofit', ...CONFIG_GROUPS_PER_ROW_NUMERIC_CHOICES];
-export const DEFAULT_GROUPS_PER_ROW = 4;
+export const CONFIG_GROUPS_PER_ROW_CHOICES = ['Autofit', ...CONFIG_GROUPS_PER_ROW_NUMERIC_CHOICES] as const;
+export type GroupsPerRowOption = (typeof CONFIG_GROUPS_PER_ROW_CHOICES)[number];
+export const DEFAULT_GROUPS_PER_ROW: GroupsPerRowOption = 4;
 
 // Scroll
 export const CONFIG_SCROLLING_BEHAVIOR = 'scrollingBehavior';

--- a/src/plugin/manifest.ts
+++ b/src/plugin/manifest.ts
@@ -14,10 +14,12 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+// Common
 export const PACKAGE_NAME = 'memory-inspector';
 export const DISPLAY_NAME = 'Memory Inspector';
 export const EDITOR_NAME = `${PACKAGE_NAME}.inspect`;
 
+// Misc
 export const CONFIG_LOGGING_VERBOSITY = 'loggingVerbosity';
 export const DEFAULT_LOGGING_VERBOSITY = 'warn';
 export const CONFIG_DEBUG_TYPES = 'debugTypes';
@@ -25,12 +27,25 @@ export const DEFAULT_DEBUG_TYPES = ['gdb', 'embedded-debug', 'arm-debugger'];
 export const CONFIG_REFRESH_ON_STOP = 'refreshOnStop';
 export const DEFAULT_REFRESH_ON_STOP = 'on';
 
+// Words
+// - Bytes per Word
 export const CONFIG_BYTES_PER_WORD = 'groupings.bytesPerWord';
+export const CONFIG_BYTES_PER_WORD_CHOICES = [1, 2, 4, 8, 16];
 export const DEFAULT_BYTES_PER_WORD = 1;
+
+// - Words per Group
 export const CONFIG_WORDS_PER_GROUP = 'groupings.wordsPerGroup';
+export const CONFIG_WORDS_PER_GROUP_CHOICES = [1, 2, 4, 8, 16];
 export const DEFAULT_WORDS_PER_GROUP = 1;
+
+// - Groups per Row
+export type GroupsPerRowChoices = ['Autofit', ...number[]];
 export const CONFIG_GROUPS_PER_ROW = 'groupings.groupsPerRow';
+export const CONFIG_GROUPS_PER_ROW_NUMERIC_CHOICES = [1, 2, 4, 8, 16, 32] as const;
+export const CONFIG_GROUPS_PER_ROW_CHOICES: GroupsPerRowChoices = ['Autofit', ...CONFIG_GROUPS_PER_ROW_NUMERIC_CHOICES];
 export const DEFAULT_GROUPS_PER_ROW = 4;
+
+// Scroll
 export const CONFIG_SCROLLING_BEHAVIOR = 'scrollingBehavior';
 export const DEFAULT_SCROLLING_BEHAVIOR = 'Paginate';
 export const CONFIG_ADDRESS_RADIX = 'addressRadix';
@@ -38,5 +53,6 @@ export const DEFAULT_ADDRESS_RADIX = 16;
 export const CONFIG_SHOW_RADIX_PREFIX = 'showRadixPrefix';
 export const DEFAULT_SHOW_RADIX_PREFIX = true;
 
+// Columns
 export const CONFIG_SHOW_VARIABLES_COLUMN = 'columns.variables';
 export const CONFIG_SHOW_ASCII_COLUMN = 'columns.ascii';

--- a/src/plugin/memory-webview-main.ts
+++ b/src/plugin/memory-webview-main.ts
@@ -220,7 +220,7 @@ export class MemoryWebview implements vscode.CustomReadonlyEditorProvider {
         const memoryInspectorConfiguration = vscode.workspace.getConfiguration(manifest.PACKAGE_NAME);
         const bytesPerWord = memoryInspectorConfiguration.get<number>(manifest.CONFIG_BYTES_PER_WORD, manifest.DEFAULT_BYTES_PER_WORD);
         const wordsPerGroup = memoryInspectorConfiguration.get<number>(manifest.CONFIG_WORDS_PER_GROUP, manifest.DEFAULT_WORDS_PER_GROUP);
-        const groupsPerRow = memoryInspectorConfiguration.get<number>(manifest.CONFIG_GROUPS_PER_ROW, manifest.DEFAULT_GROUPS_PER_ROW);
+        const groupsPerRow = memoryInspectorConfiguration.get<manifest.GroupsPerRowOption>(manifest.CONFIG_GROUPS_PER_ROW, manifest.DEFAULT_GROUPS_PER_ROW);
         const scrollingBehavior = memoryInspectorConfiguration.get<ScrollingBehavior>(manifest.CONFIG_SCROLLING_BEHAVIOR, manifest.DEFAULT_SCROLLING_BEHAVIOR);
         const visibleColumns = CONFIGURABLE_COLUMNS
             .filter(column => vscode.workspace.getConfiguration(manifest.PACKAGE_NAME).get<boolean>(column, false))

--- a/src/webview/columns/address-column.tsx
+++ b/src/webview/columns/address-column.tsx
@@ -16,7 +16,7 @@
 
 import React, { ReactNode } from 'react';
 import { BigIntMemoryRange, getAddressString, getRadixMarker } from '../../common/memory-range';
-import { ColumnContribution } from './column-contribution-service';
+import { ColumnContribution, ColumnFittingType } from './column-contribution-service';
 import { Memory, MemoryDisplayConfiguration } from '../utils/view-types';
 
 export class AddressColumn implements ColumnContribution {
@@ -25,6 +25,8 @@ export class AddressColumn implements ColumnContribution {
     readonly id = AddressColumn.ID;
     readonly label = 'Address';
     readonly priority = 0;
+
+    fittingType: ColumnFittingType = 'content-width';
 
     render(range: BigIntMemoryRange, _: Memory, options: MemoryDisplayConfiguration): ReactNode {
         return <span className='memory-start-address'>

--- a/src/webview/columns/column-contribution-service.ts
+++ b/src/webview/columns/column-contribution-service.ts
@@ -19,9 +19,14 @@ import type * as React from 'react';
 import { BigIntMemoryRange } from '../../common/memory-range';
 import type { Disposable, Memory, MemoryState, SerializedTableRenderOptions, UpdateExecutor } from '../utils/view-types';
 
+export type ColumnFittingType = 'content-width';
+
 export interface ColumnContribution {
-    readonly label: string;
     readonly id: string;
+    readonly className?: string;
+    readonly label: string;
+    /** Depending on the supported fitting mode, the column will be rendered differently */
+    fittingType?: ColumnFittingType;
     /** Sorted low to high. If ommitted, sorted alphabetically by ID after all contributions with numbers. */
     priority?: number;
     render(range: BigIntMemoryRange, memory: Memory, options: TableRenderOptions): React.ReactNode

--- a/src/webview/columns/data-column.tsx
+++ b/src/webview/columns/data-column.tsx
@@ -107,8 +107,9 @@ export namespace DataColumn {
             return 1;
         }
         const columnWidth = elementInnerWidth(element);
-        const characterWidth = characterWidthInContainer(element, '0');
-        const groupWidth = characterWidth
+        // The browser also rounds the character width
+        const charactersWidth = Math.round((characterWidthInContainer(element, '0') + Number.EPSILON) * 100) / 100;
+        const groupWidth = charactersWidth
             * 2 // characters per byte
             * options.bytesPerWord
             * options.wordsPerGroup

--- a/src/webview/columns/data-column.tsx
+++ b/src/webview/columns/data-column.tsx
@@ -23,10 +23,9 @@ import type { MemorySizeOptions } from '../components/memory-table';
 import { elementInnerWidth, characterWidthInContainer } from '../utils/window';
 
 export class DataColumn implements ColumnContribution {
-    static ID = 'data';
     static CLASS_NAME = 'column-data';
 
-    readonly id = DataColumn.ID;
+    readonly id = 'data';
     readonly className = DataColumn.CLASS_NAME;
     readonly label = 'Data';
     readonly priority = 1;

--- a/src/webview/columns/data-column.tsx
+++ b/src/webview/columns/data-column.tsx
@@ -35,7 +35,7 @@ export class DataColumn implements ColumnContribution {
     };
 
     render(range: BigIntMemoryRange, memory: Memory, options: TableRenderOptions): React.ReactNode {
-        return this.renderGroups(range, memory, options);
+        return <div className='data-groups-container'>{this.renderGroups(range, memory, options)}</div>;
     }
 
     protected renderGroups(range: BigIntMemoryRange, memory: Memory, options: TableRenderOptions): React.ReactNode {

--- a/src/webview/columns/data-column.tsx
+++ b/src/webview/columns/data-column.tsx
@@ -19,11 +19,21 @@ import { BigIntMemoryRange, toOffset } from '../../common/memory-range';
 import { FullNodeAttributes, Memory } from '../utils/view-types';
 import { ColumnContribution, TableRenderOptions } from './column-contribution-service';
 import { decorationService } from '../decorations/decoration-service';
+import type { MemorySizeOptions } from '../components/memory-table';
+import { elementInnerWidth, characterWidthInContainer } from '../utils/window';
 
 export class DataColumn implements ColumnContribution {
-    readonly id = 'data';
+    static ID = 'data';
+    static CLASS_NAME = 'column-data';
+
+    readonly id = DataColumn.ID;
+    readonly className = DataColumn.CLASS_NAME;
     readonly label = 'Data';
     readonly priority = 1;
+
+    protected byteGroupStyle: React.CSSProperties = {
+        marginRight: `${DataColumn.Styles.MARGIN_RIGHT_PX}px`
+    };
 
     render(range: BigIntMemoryRange, memory: Memory, options: TableRenderOptions): React.ReactNode {
         return this.renderGroups(range, memory, options);
@@ -35,7 +45,10 @@ export class DataColumn implements ColumnContribution {
         for (let i = range.startAddress; i < range.endAddress; i++) {
             words.push(this.renderWord(memory, options, i));
             if (words.length % options.wordsPerGroup === 0) {
-                groups.push(<span className='byte-group' key={i.toString(16)}>{words}</span>);
+                const isLast = i + 1n >= range.endAddress;
+                const style: React.CSSProperties | undefined = isLast ? undefined : this.byteGroupStyle;
+
+                groups.push(<span className='byte-group' style={style} key={i.toString(16)}>{words}</span>);
                 words = [];
             }
         }
@@ -72,5 +85,38 @@ export class DataColumn implements ColumnContribution {
             style: decorationService.getDecoration(currentAdress)?.style,
             content: (memory.bytes[offset] ?? 0).toString(16).padStart(2, '0')
         };
+    }
+}
+
+export namespace DataColumn {
+    export namespace Styles {
+        export const MARGIN_RIGHT_PX = 2;
+    }
+
+    /**
+     * The approximation is done by:
+     *
+     * 1. Calculating the group width including factors such as character size
+     * 2. Dividing column width by group width
+     *
+     * @returns Approximated groups per row that will fit into the element
+     */
+    export function approximateGroupsPerRow(row: HTMLElement, options: MemorySizeOptions): number {
+        const element = row.querySelector<HTMLElement>(`.${DataColumn.CLASS_NAME}`);
+        // eslint-disable-next-line no-null/no-null
+        if (element === null) {
+            return 1;
+        }
+        const columnWidth = elementInnerWidth(element);
+        const characterWidth = characterWidthInContainer(element, '0');
+        const groupWidth = characterWidth
+            * 2 // characters per byte
+            * options.bytesPerWord
+            * options.wordsPerGroup
+            + Styles.MARGIN_RIGHT_PX;
+        // Accommodate the non-existent margin of the final element.
+        const maxGroups = Math.max((columnWidth + Styles.MARGIN_RIGHT_PX) / groupWidth, 1);
+
+        return Math.floor(maxGroups);
     }
 }

--- a/src/webview/components/memory-table.tsx
+++ b/src/webview/components/memory-table.tsx
@@ -240,7 +240,7 @@ export class MemoryTable extends React.PureComponent<MemoryTableProps, MemoryTab
     protected createDataTableProperties(rows: MemoryRowData[]): DataTableProps<MemoryRowData[]> {
         return {
             cellSelection: true,
-            className: MemoryTable.TABLE_CLASS,
+            className: classNames(MemoryTable.TABLE_CLASS, { [MemoryTable.TABLE_GROUPS_PER_ROW_AUTOFIT]: this.props.groupsPerRow === 'Autofit' }),
             footer: this.renderFooter(),
             header: this.renderHeader(),
             lazy: true,
@@ -390,5 +390,6 @@ export class MemoryTable extends React.PureComponent<MemoryTableProps, MemoryTab
 }
 
 export namespace MemoryTable {
-    export const TABLE_CLASS = 'memory-inspector-table';
+    export const TABLE_CLASS = 'memory-inspector-table' as const;
+    export const TABLE_GROUPS_PER_ROW_AUTOFIT = 'groups-per-row-autofit' as const;
 }

--- a/src/webview/components/memory-table.tsx
+++ b/src/webview/components/memory-table.tsx
@@ -216,9 +216,9 @@ export class MemoryTable extends React.PureComponent<MemoryTableProps, MemoryTab
                     {...props}
                 >
                     {this.props.columnOptions.map(({ contribution }) => {
-                        const isContentWidhtFit = contribution.fittingType === 'content-width';
+                        const isContentWidthFit = contribution.fittingType === 'content-width';
                         const className = classNames(contribution.className, {
-                            'content-width-fit': isContentWidhtFit
+                            'content-width-fit': isContentWidthFit
                         });
 
                         return <Column
@@ -227,7 +227,7 @@ export class MemoryTable extends React.PureComponent<MemoryTableProps, MemoryTab
                             header={contribution.label}
                             className={className}
                             headerClassName={className}
-                            style={{ width: isContentWidhtFit ? undefined : `${columnWidth}%` }}
+                            style={{ width: isContentWidthFit ? undefined : `${columnWidth}%` }}
                             body={(row?: MemoryRowData) => row && contribution.render(row, this.props.memory!, this.props)}>
                             {contribution.label}
                         </Column>;

--- a/src/webview/components/options-widget.tsx
+++ b/src/webview/components/options-widget.tsx
@@ -27,6 +27,8 @@ import {
     SerializedTableRenderOptions,
 } from '../utils/view-types';
 import { MultiSelectWithLabel } from './multi-select';
+import { CONFIG_BYTES_PER_WORD_CHOICES, CONFIG_GROUPS_PER_ROW_CHOICES, CONFIG_WORDS_PER_GROUP_CHOICES } from '../../plugin/manifest';
+import { tryToNumber } from '../../common/typescript';
 import { Checkbox } from 'primereact/checkbox';
 
 export interface OptionsWidgetProps
@@ -65,10 +67,6 @@ interface OptionsForm {
     offset: string;
     count: string;
 }
-
-const allowedBytesPerWord = [1, 2, 4, 8, 16];
-const allowedWordsPerGroup = [1, 2, 4, 8, 16];
-const allowedGroupsPerRow = [1, 2, 4, 8, 16, 32];
 
 export class OptionsWidget extends React.Component<OptionsWidgetProps, OptionsWidgetState> {
     protected formConfig: FormikConfig<OptionsForm>;
@@ -294,7 +292,7 @@ export class OptionsWidget extends React.Component<OptionsWidgetProps, OptionsWi
                                 id={InputId.BytesPerWord}
                                 value={this.props.bytesPerWord}
                                 onChange={this.handleAdvancedOptionsDropdownChange}
-                                options={allowedBytesPerWord}
+                                options={CONFIG_BYTES_PER_WORD_CHOICES}
                                 className='advanced-options-dropdown' />
 
                             <label
@@ -307,7 +305,7 @@ export class OptionsWidget extends React.Component<OptionsWidgetProps, OptionsWi
                                 id={InputId.WordsPerGroup}
                                 value={this.props.wordsPerGroup}
                                 onChange={this.handleAdvancedOptionsDropdownChange}
-                                options={allowedWordsPerGroup}
+                                options={CONFIG_WORDS_PER_GROUP_CHOICES}
                                 className='advanced-options-dropdown' />
                             <label
                                 htmlFor={InputId.GroupsPerRow}
@@ -319,7 +317,7 @@ export class OptionsWidget extends React.Component<OptionsWidgetProps, OptionsWi
                                 id={InputId.GroupsPerRow}
                                 value={this.props.groupsPerRow}
                                 onChange={this.handleAdvancedOptionsDropdownChange}
-                                options={allowedGroupsPerRow}
+                                options={CONFIG_GROUPS_PER_ROW_CHOICES}
                                 className='advanced-options-dropdown' />
 
                             <h2>Address Format</h2>
@@ -416,7 +414,7 @@ export class OptionsWidget extends React.Component<OptionsWidgetProps, OptionsWi
                 this.props.updateRenderOptions({ wordsPerGroup: Number(value) });
                 break;
             case InputId.GroupsPerRow:
-                this.props.updateRenderOptions({ groupsPerRow: Number(value) });
+                this.props.updateRenderOptions({ groupsPerRow: tryToNumber(value) ?? value });
                 break;
             case InputId.AddressRadix:
                 this.props.updateRenderOptions({ addressRadix: Number(value) });

--- a/src/webview/components/options-widget.tsx
+++ b/src/webview/components/options-widget.tsx
@@ -292,7 +292,7 @@ export class OptionsWidget extends React.Component<OptionsWidgetProps, OptionsWi
                                 id={InputId.BytesPerWord}
                                 value={this.props.bytesPerWord}
                                 onChange={this.handleAdvancedOptionsDropdownChange}
-                                options={CONFIG_BYTES_PER_WORD_CHOICES}
+                                options={[...CONFIG_BYTES_PER_WORD_CHOICES]}
                                 className='advanced-options-dropdown' />
 
                             <label
@@ -305,7 +305,7 @@ export class OptionsWidget extends React.Component<OptionsWidgetProps, OptionsWi
                                 id={InputId.WordsPerGroup}
                                 value={this.props.wordsPerGroup}
                                 onChange={this.handleAdvancedOptionsDropdownChange}
-                                options={CONFIG_WORDS_PER_GROUP_CHOICES}
+                                options={[...CONFIG_WORDS_PER_GROUP_CHOICES]}
                                 className='advanced-options-dropdown' />
                             <label
                                 htmlFor={InputId.GroupsPerRow}
@@ -317,7 +317,7 @@ export class OptionsWidget extends React.Component<OptionsWidgetProps, OptionsWi
                                 id={InputId.GroupsPerRow}
                                 value={this.props.groupsPerRow}
                                 onChange={this.handleAdvancedOptionsDropdownChange}
-                                options={CONFIG_GROUPS_PER_ROW_CHOICES}
+                                options={[...CONFIG_GROUPS_PER_ROW_CHOICES]}
                                 className='advanced-options-dropdown' />
 
                             <h2>Address Format</h2>

--- a/src/webview/utils/view-types.ts
+++ b/src/webview/utils/view-types.ts
@@ -18,6 +18,8 @@ import type { DebugProtocol } from '@vscode/debugprotocol';
 import deepequal from 'fast-deep-equal';
 import type * as React from 'react';
 import { areRangesEqual, BigIntMemoryRange, Radix } from '../../common/memory-range';
+import { GroupsPerRowChoices } from '../../plugin/manifest';
+import { TypeOfArrayElement } from '../../common/typescript';
 
 export enum Endianness {
     Little = 'Little Endian',
@@ -81,7 +83,7 @@ export interface MemoryViewSettings extends ColumnVisibilityStatus, MemoryDispla
 export interface MemoryDisplayConfiguration {
     bytesPerWord: number;
     wordsPerGroup: number;
-    groupsPerRow: number;
+    groupsPerRow: TypeOfArrayElement<GroupsPerRowChoices>;
     scrollingBehavior: ScrollingBehavior;
     addressRadix: Radix;
     showRadixPrefix: boolean;

--- a/src/webview/utils/view-types.ts
+++ b/src/webview/utils/view-types.ts
@@ -18,8 +18,7 @@ import type { DebugProtocol } from '@vscode/debugprotocol';
 import deepequal from 'fast-deep-equal';
 import type * as React from 'react';
 import { areRangesEqual, BigIntMemoryRange, Radix } from '../../common/memory-range';
-import { GroupsPerRowChoices } from '../../plugin/manifest';
-import { TypeOfArrayElement } from '../../common/typescript';
+import { GroupsPerRowOption } from '../../plugin/manifest';
 
 export enum Endianness {
     Little = 'Little Endian',
@@ -83,7 +82,7 @@ export interface MemoryViewSettings extends ColumnVisibilityStatus, MemoryDispla
 export interface MemoryDisplayConfiguration {
     bytesPerWord: number;
     wordsPerGroup: number;
-    groupsPerRow: TypeOfArrayElement<GroupsPerRowChoices>;
+    groupsPerRow: GroupsPerRowOption;
     scrollingBehavior: ScrollingBehavior;
     addressRadix: Radix;
     showRadixPrefix: boolean;

--- a/src/webview/utils/window.ts
+++ b/src/webview/utils/window.ts
@@ -20,8 +20,7 @@
 export function elementInnerWidth(element: HTMLElement): number {
     const styles = window.getComputedStyle(element);
     const padding = parseFloat(styles.paddingLeft) + parseFloat(styles.paddingRight);
-    const columnWidth = element.clientWidth - padding;
-    return columnWidth;
+    return parseFloat(styles.width) - padding;
 }
 
 /**
@@ -31,14 +30,14 @@ export function elementInnerWidth(element: HTMLElement): number {
  */
 export function characterWidthInContainer(container: HTMLElement, text: string): number {
     let width = 1;
-    const font = window.getComputedStyle(container).font;
-
+    const style = window.getComputedStyle(container);
+    const font = `${style.fontWeight} ${style.fontSize} ${style.fontFamily}`;
     const canvas = document.createElement('canvas');
     const context = canvas.getContext('2d');
 
     if (context) {
         context.font = font;
-        width = Math.ceil(context.measureText(text).width);
+        width = context.measureText(text).width;
     }
 
     return width;

--- a/src/webview/utils/window.ts
+++ b/src/webview/utils/window.ts
@@ -1,0 +1,45 @@
+/********************************************************************************
+ * Copyright (C) 2024 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+/**
+ * Calculates the width of the element without any padding / margin / border
+ */
+export function elementInnerWidth(element: HTMLElement): number {
+    const styles = window.getComputedStyle(element);
+    const padding = parseFloat(styles.paddingLeft) + parseFloat(styles.paddingRight);
+    const columnWidth = element.clientWidth - padding;
+    return columnWidth;
+}
+
+/**
+ * Calculates the width of the provided text within the container
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/measureText
+ */
+export function characterWidthInContainer(container: HTMLElement, text: string): number {
+    let width = 1;
+    const font = window.getComputedStyle(container).font;
+
+    const canvas = document.createElement('canvas');
+    const context = canvas.getContext('2d');
+
+    if (context) {
+        context.font = font;
+        width = Math.ceil(context.measureText(text).width);
+    }
+
+    return width;
+}


### PR DESCRIPTION
#### What it does

Introduces the `Autofit` element for `Groups per Row`.

~**IMPORTANT**: The selected `Groups per Row` is based on the available choices! That means, it is not possible to render, e.g., 7 groups per rows (*for now*). HOWEVER, code-wise it should be still possible if requested.~  

#### How to test

1. Select `Autofit` in the options for `Groups per Row`
2. Change `Bytes per Word`, `Words per Group` or toggle the columns
3. Resize either the view or the colums
4. Go to 2.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Closes #73
