### PR TITLE
Allow to freeze content of a memory view instance

### DIFF
--- a/media/memory-table.css
+++ b/media/memory-table.css
@@ -36,7 +36,6 @@
   border: 1px solid var(--vscode-dropdown-border);
   background: var(--vscode-dropdown-background);
   outline: none;
-  cursor: pointer;
 }
 
 .more-memory-select {
@@ -44,6 +43,9 @@
   justify-content: center;
   align-items: center;
   font-style: italic;
+}
+
+.more-memory-select:not(.p-disabled) {
   cursor: pointer;
 }
 
@@ -56,14 +58,10 @@
   border-color: transparent;
 }
 
-.more-memory-select:hover:not(.disabled) .more-memory-select-top {
+.more-memory-select:hover:not(.p-disabled) .more-memory-select-top {
   border-bottom: 1px solid;
   padding-bottom: 0;
   border-color: var(--vscode-sideBar-foreground);
-}
-
-.more-memory-select.disabled .more-memory-select-top {
-  color: var(--vscode-disabledForeground);
 }
 
 .more-memory-select select {
@@ -76,7 +74,7 @@
   font-style: italic;
 }
 
-.more-memory-select select:hover:not(:disabled) {
+.more-memory-select select:hover:not(.p-disabled) {
   background: var(--vscode-dropdown-background);
 }
 
@@ -85,5 +83,5 @@
 }
 
 .radix-prefix {
-  opacity: .6;
+  opacity: 0.6;
 }

--- a/media/memory-table.css
+++ b/media/memory-table.css
@@ -56,10 +56,14 @@
   border-color: transparent;
 }
 
-.more-memory-select:hover .more-memory-select-top {
+.more-memory-select:hover:not(.disabled) .more-memory-select-top {
   border-bottom: 1px solid;
   padding-bottom: 0;
   border-color: var(--vscode-sideBar-foreground);
+}
+
+.more-memory-select.disabled .more-memory-select-top {
+  color: var(--vscode-disabledForeground);
 }
 
 .more-memory-select select {
@@ -72,7 +76,7 @@
   font-style: italic;
 }
 
-.more-memory-select select:hover {
+.more-memory-select select:hover:not(:disabled) {
   background: var(--vscode-dropdown-background);
 }
 

--- a/media/options-widget.css
+++ b/media/options-widget.css
@@ -65,11 +65,6 @@
   border-top: 1px solid var(--vscode-widget-border);
 }
 
-.core-options input:disabled,
-.core-options .disabled {
-  color: var(--vscode-disabledForeground);
-}
-
 .form-options {
   display: flex;
   flex-direction: row;

--- a/media/options-widget.css
+++ b/media/options-widget.css
@@ -27,7 +27,7 @@
 .memory-options-widget .title-container h1 {
   flex-grow: 1;
   font-size: 1.3em;
-  margin: 8px 0 4px;
+  margin: 8px 5px 4px;
 }
 
 .memory-options-widget .title-container input {
@@ -47,6 +47,14 @@
   opacity: 1;
 }
 
+.memory-options-widget .freeze-content-toggle {
+  margin-top: 4px;
+}
+
+.memory-options-widget .freeze-content-toggle.toggled {
+  background-color: var(--vscode-button-secondaryBackground);
+}
+
 .core-options {
   display: flex;
   flex-direction: row;
@@ -55,6 +63,11 @@
   flex-wrap: wrap;
   border-bottom: 1px solid var(--vscode-widget-border);
   border-top: 1px solid var(--vscode-widget-border);
+}
+
+.core-options input:disabled,
+.core-options .disabled {
+  color: var(--vscode-disabledForeground);
 }
 
 .form-options {

--- a/media/theme/extensions.css
+++ b/media/theme/extensions.css
@@ -22,10 +22,20 @@
 
 .pm-top-label .p-inputtext-label {
   margin-bottom: 2px;
+}
+
+.p-inputtext-label:not(.p-disabled) {
   cursor: pointer;
 }
 
 small.p-invalid {
   margin-top: 4px;
   color: var(--vscode-errorForeground);
+}
+
+.p-disabled,
+.p-disabled * {
+  pointer-events: auto;
+  cursor: not-allowed;
+  color: var(--vscode-disabledForeground);
 }

--- a/src/webview/components/memory-table.tsx
+++ b/src/webview/components/memory-table.tsx
@@ -33,9 +33,10 @@ export interface MoreMemorySelectProps {
     direction: 'above' | 'below';
     scrollingBehavior: ScrollingBehavior;
     fetchMemory(partialOptions?: Partial<DebugProtocol.ReadMemoryArguments>): Promise<void>;
+    disabled: boolean
 }
 
-export const MoreMemorySelect: React.FC<MoreMemorySelectProps> = ({ count, offset, options, fetchMemory, direction, scrollingBehavior }) => {
+export const MoreMemorySelect: React.FC<MoreMemorySelectProps> = ({ count, offset, options, fetchMemory, direction, scrollingBehavior, disabled }) => {
     const [numBytes, setNumBytes] = React.useState<number>(options[0]);
     const containerRef = React.createRef<HTMLDivElement>();
     const onSelectChange = (e: React.ChangeEvent<HTMLSelectElement>): void => {
@@ -65,7 +66,7 @@ export const MoreMemorySelect: React.FC<MoreMemorySelectProps> = ({ count, offse
 
     return (
         <div
-            className='more-memory-select'
+            className={`more-memory-select ${disabled ? 'disabled' : ''}`}
             tabIndex={0}
             role='button'
             onClick={loadMoreMemory}
@@ -78,6 +79,7 @@ export const MoreMemorySelect: React.FC<MoreMemorySelectProps> = ({ count, offse
                     className='bytes-select'
                     onChange={onSelectChange}
                     tabIndex={0}
+                    disabled={disabled}
                 >
                     {options.map(option => (
                         <option
@@ -100,6 +102,7 @@ interface MemoryTableProps extends TableRenderOptions, MemoryDisplayConfiguratio
     count: number;
     fetchMemory(partialOptions?: Partial<DebugProtocol.ReadMemoryArguments>): Promise<void>;
     isMemoryFetching: boolean;
+    isFrozen: boolean;
 }
 
 interface MemoryRowListOptions {
@@ -242,6 +245,7 @@ export class MemoryTable extends React.PureComponent<MemoryTableProps, MemoryTab
                     direction='above'
                     scrollingBehavior={scrollingBehavior}
                     fetchMemory={fetchMemory}
+                    disabled={this.props.isFrozen}
                 />
             </div>;
         }
@@ -275,6 +279,7 @@ export class MemoryTable extends React.PureComponent<MemoryTableProps, MemoryTab
                     direction='below'
                     scrollingBehavior={scrollingBehavior}
                     fetchMemory={fetchMemory}
+                    disabled={this.props.isFrozen}
                 />
             </div>;
         }

--- a/src/webview/components/memory-table.tsx
+++ b/src/webview/components/memory-table.tsx
@@ -66,7 +66,7 @@ export const MoreMemorySelect: React.FC<MoreMemorySelectProps> = ({ count, offse
 
     return (
         <div
-            className={`more-memory-select ${disabled ? 'disabled' : ''}`}
+            className={`more-memory-select ${disabled ? 'p-disabled' : ''}`}
             tabIndex={0}
             role='button'
             onClick={loadMoreMemory}
@@ -76,7 +76,7 @@ export const MoreMemorySelect: React.FC<MoreMemorySelectProps> = ({ count, offse
             <div className='more-memory-select-top no-select'>
                 Load
                 <select
-                    className='bytes-select'
+                    className={`bytes-select ${disabled ? 'p-disabled' : ''}`}
                     onChange={onSelectChange}
                     tabIndex={0}
                     disabled={disabled}

--- a/src/webview/components/memory-widget.tsx
+++ b/src/webview/components/memory-widget.tsx
@@ -34,7 +34,7 @@ interface MemoryWidgetProps extends MemoryDisplayConfiguration {
     updateMemoryArguments: (memoryArguments: Partial<DebugProtocol.ReadMemoryArguments>) => void;
     toggleColumn(id: string, active: boolean): void;
     isFrozen: boolean;
-    toggleFreezeButton: () => void;
+    toggleFrozen: () => void;
     updateMemoryDisplayConfiguration: (memoryArguments: Partial<MemoryDisplayConfiguration>) => void;
     resetMemoryDisplayConfiguration: () => void;
     updateTitle: (title: string) => void;
@@ -75,7 +75,7 @@ export class MemoryWidget extends React.Component<MemoryWidgetProps, MemoryWidge
                 addressRadix={this.props.addressRadix}
                 showRadixPrefix={this.props.showRadixPrefix}
                 toggleColumn={this.props.toggleColumn}
-                toggleFreezeButton={this.props.toggleFreezeButton}
+                toggleFrozen={this.props.toggleFrozen}
                 isFrozen={this.props.isFrozen}
             />
             <MemoryTable

--- a/src/webview/components/memory-widget.tsx
+++ b/src/webview/components/memory-widget.tsx
@@ -33,6 +33,8 @@ interface MemoryWidgetProps extends MemoryDisplayConfiguration {
     refreshMemory: () => void;
     updateMemoryArguments: (memoryArguments: Partial<DebugProtocol.ReadMemoryArguments>) => void;
     toggleColumn(id: string, active: boolean): void;
+    isFrozen: boolean;
+    toggleFreezeButton: () => void;
     updateMemoryDisplayConfiguration: (memoryArguments: Partial<MemoryDisplayConfiguration>) => void;
     resetMemoryDisplayConfiguration: () => void;
     updateTitle: (title: string) => void;
@@ -73,6 +75,8 @@ export class MemoryWidget extends React.Component<MemoryWidgetProps, MemoryWidge
                 addressRadix={this.props.addressRadix}
                 showRadixPrefix={this.props.showRadixPrefix}
                 toggleColumn={this.props.toggleColumn}
+                toggleFreezeButton={this.props.toggleFreezeButton}
+                isFrozen={this.props.isFrozen}
             />
             <MemoryTable
                 decorations={this.props.decorations}
@@ -89,6 +93,7 @@ export class MemoryWidget extends React.Component<MemoryWidgetProps, MemoryWidge
                 scrollingBehavior={this.props.scrollingBehavior}
                 addressRadix={this.props.addressRadix}
                 showRadixPrefix={this.props.showRadixPrefix}
+                isFrozen={this.props.isFrozen}
             />
         </div>);
     }

--- a/src/webview/components/options-widget.tsx
+++ b/src/webview/components/options-widget.tsx
@@ -41,6 +41,8 @@ export interface OptionsWidgetProps
     ) => void;
     refreshMemory: () => void;
     toggleColumn(id: string, isVisible: boolean): void;
+    toggleFreezeButton: () => void;
+    isFrozen: boolean;
 }
 
 interface OptionsWidgetState {
@@ -140,10 +142,22 @@ export class OptionsWidget extends React.Component<OptionsWidgetProps, OptionsWi
     override render(): React.ReactNode {
         this.formConfig.initialValues = this.optionsFormValues;
         const isLabelEditing = this.state.isTitleEditing;
+        const isFrozen = this.props.isFrozen;
+        const freezeContentToggleTitle = isFrozen ? 'Unfreeze Memory View' : 'Freeze Memory View';
 
         return (
             <div className='memory-options-widget px-4'>
                 <div className='title-container'>
+                    <Button
+                        type='button'
+                        className={`freeze-content-toggle ${isFrozen ? 'toggled' : ''}`}
+                        icon={'codicon codicon-' + (isFrozen ? 'lock' : 'unlock')}
+                        onClick={this.props.toggleFreezeButton}
+                        title={freezeContentToggleTitle}
+                        aria-label={freezeContentToggleTitle}
+                        rounded
+                        aria-haspopup
+                    />
                     <InputText
                         ref={this.labelEditInput}
                         type='text'
@@ -168,11 +182,11 @@ export class OptionsWidget extends React.Component<OptionsWidgetProps, OptionsWi
                     )}
                 </div>
                 <div className='core-options py-2'>
-                    <Formik {...this.formConfig}>
+                    <Formik {...this.formConfig} >
                         {formik => (
-                            <form onSubmit={formik.handleSubmit} className='form-options'>
+                            <form onSubmit={formik.handleSubmit} className='form-options' >
                                 <span className='pm-top-label form-texfield-long'>
-                                    <label htmlFor={InputId.Address} className='p-inputtext-label'>
+                                    <label htmlFor={InputId.Address} className={`p-inputtext-label ${isFrozen ? 'disabled' : ''}`} >
                                         Address
                                     </label>
                                     <InputText
@@ -181,6 +195,7 @@ export class OptionsWidget extends React.Component<OptionsWidgetProps, OptionsWi
                                         {...formik.getFieldProps('address')}
                                         onKeyDown={this.handleKeyDown}
                                         onBlur={ev => this.doHandleBlur(ev, formik)}
+                                        disabled={isFrozen}
                                     />
                                     {formik.errors.address ?
                                         (<small className='p-invalid'>
@@ -189,7 +204,7 @@ export class OptionsWidget extends React.Component<OptionsWidgetProps, OptionsWi
                                         : undefined}
                                 </span>
                                 <span className='pm-top-label form-textfield'>
-                                    <label htmlFor={InputId.Offset} className='p-inputtext-label'>
+                                    <label htmlFor={InputId.Offset} className={`p-inputtext-label ${isFrozen ? 'disabled' : ''}`}>
                                         Offset
                                     </label>
                                     <InputText
@@ -198,6 +213,7 @@ export class OptionsWidget extends React.Component<OptionsWidgetProps, OptionsWi
                                         {...formik.getFieldProps('offset')}
                                         onKeyDown={this.handleKeyDown}
                                         onBlur={ev => this.doHandleBlur(ev, formik)}
+                                        disabled={isFrozen}
                                     />
                                     {formik.errors.offset ?
                                         (<small className='p-invalid'>
@@ -206,7 +222,7 @@ export class OptionsWidget extends React.Component<OptionsWidgetProps, OptionsWi
                                         : undefined}
                                 </span>
                                 <span className='pm-top-label form-textfield'>
-                                    <label htmlFor={InputId.Length} className='p-inputtext-label'>
+                                    <label htmlFor={InputId.Length} className={`p-inputtext-label ${isFrozen ? 'disabled' : ''}`}>
                                         Length
                                     </label>
                                     <InputText
@@ -215,6 +231,7 @@ export class OptionsWidget extends React.Component<OptionsWidgetProps, OptionsWi
                                         {...formik.getFieldProps('count')}
                                         onKeyDown={this.handleKeyDown}
                                         onBlur={ev => this.doHandleBlur(ev, formik)}
+                                        disabled={isFrozen}
                                     />
                                     {formik.errors.count ?
                                         (<small className='p-invalid'>
@@ -222,7 +239,7 @@ export class OptionsWidget extends React.Component<OptionsWidgetProps, OptionsWi
                                         </small>)
                                         : undefined}
                                 </span>
-                                <Button type='submit' disabled={!formik.isValid}>
+                                <Button type='submit' disabled={!formik.isValid || isFrozen}>
                                     Go
                                 </Button>
                             </form>

--- a/src/webview/components/options-widget.tsx
+++ b/src/webview/components/options-widget.tsx
@@ -41,7 +41,7 @@ export interface OptionsWidgetProps
     ) => void;
     refreshMemory: () => void;
     toggleColumn(id: string, isVisible: boolean): void;
-    toggleFreezeButton: () => void;
+    toggleFrozen: () => void;
     isFrozen: boolean;
 }
 
@@ -152,7 +152,7 @@ export class OptionsWidget extends React.Component<OptionsWidgetProps, OptionsWi
                         type='button'
                         className={`freeze-content-toggle ${isFrozen ? 'toggled' : ''}`}
                         icon={'codicon codicon-' + (isFrozen ? 'lock' : 'unlock')}
-                        onClick={this.props.toggleFreezeButton}
+                        onClick={this.props.toggleFrozen}
                         title={freezeContentToggleTitle}
                         aria-label={freezeContentToggleTitle}
                         rounded
@@ -184,9 +184,9 @@ export class OptionsWidget extends React.Component<OptionsWidgetProps, OptionsWi
                 <div className='core-options py-2'>
                     <Formik {...this.formConfig} >
                         {formik => (
-                            <form onSubmit={formik.handleSubmit} className='form-options' >
-                                <span className='pm-top-label form-texfield-long'>
-                                    <label htmlFor={InputId.Address} className={`p-inputtext-label ${isFrozen ? 'disabled' : ''}`} >
+                            <form onSubmit={formik.handleSubmit} className='form-options'>
+                                <span className={'pm-top-label form-texfield-long'}>
+                                    <label htmlFor={InputId.Address} className={`p-inputtext-label ${isFrozen ? 'p-disabled' : ''}`} >
                                         Address
                                     </label>
                                     <InputText
@@ -204,7 +204,7 @@ export class OptionsWidget extends React.Component<OptionsWidgetProps, OptionsWi
                                         : undefined}
                                 </span>
                                 <span className='pm-top-label form-textfield'>
-                                    <label htmlFor={InputId.Offset} className={`p-inputtext-label ${isFrozen ? 'disabled' : ''}`}>
+                                    <label htmlFor={InputId.Offset} className={`p-inputtext-label ${isFrozen ? 'p-disabled' : ''}`}>
                                         Offset
                                     </label>
                                     <InputText
@@ -222,7 +222,7 @@ export class OptionsWidget extends React.Component<OptionsWidgetProps, OptionsWi
                                         : undefined}
                                 </span>
                                 <span className='pm-top-label form-textfield'>
-                                    <label htmlFor={InputId.Length} className={`p-inputtext-label ${isFrozen ? 'disabled' : ''}`}>
+                                    <label htmlFor={InputId.Length} className={`p-inputtext-label ${isFrozen ? 'p-disabled' : ''}`}>
                                         Length
                                     </label>
                                     <InputText

--- a/src/webview/memory-webview-view.tsx
+++ b/src/webview/memory-webview-view.tsx
@@ -43,6 +43,7 @@ export interface MemoryAppState extends MemoryState, MemoryDisplayConfiguration 
     title: string;
     decorations: Decoration[];
     columns: ColumnStatus[];
+    isFrozen: boolean;
 }
 
 const MEMORY_DISPLAY_CONFIGURATION_DEFAULTS: MemoryDisplayConfiguration = {
@@ -72,6 +73,7 @@ class App extends React.Component<{}, MemoryAppState> {
             decorations: [],
             columns: columnContributionService.getColumns(),
             isMemoryFetching: false,
+            isFrozen: false,
             ...MEMORY_DISPLAY_CONFIGURATION_DEFAULTS
         };
     }
@@ -105,6 +107,8 @@ class App extends React.Component<{}, MemoryAppState> {
                 updateTitle={this.updateTitle}
                 refreshMemory={this.refreshMemory}
                 toggleColumn={this.toggleColumn}
+                toggleFreezeButton={this.toggleFreezeButton}
+                isFrozen={this.state.isFrozen}
                 fetchMemory={this.fetchMemory}
                 isMemoryFetching={this.state.isMemoryFetching}
                 bytesPerWord={this.state.bytesPerWord}
@@ -135,6 +139,9 @@ class App extends React.Component<{}, MemoryAppState> {
 
     protected fetchMemory = async (partialOptions?: Partial<DebugProtocol.ReadMemoryArguments>): Promise<void> => this.doFetchMemory(partialOptions);
     protected async doFetchMemory(partialOptions?: Partial<DebugProtocol.ReadMemoryArguments>): Promise<void> {
+        if (this.state.isFrozen) {
+            return;
+        }
         this.setState(prev => ({ ...prev, isMemoryFetching: true }));
         const completeOptions = {
             memoryReference: partialOptions?.memoryReference || this.state.memoryReference,
@@ -177,6 +184,12 @@ class App extends React.Component<{}, MemoryAppState> {
         const columns = isVisible ? await columnContributionService.show(id, this.state) : columnContributionService.hide(id);
         this.setState(prevState => ({ ...prevState, columns }));
     }
+
+    protected toggleFreezeButton = (): void => { this.doToggleFreezeButton(); };
+    protected doToggleFreezeButton(): void {
+        this.setState(prevState => ({ ...prevState, isFrozen: !prevState.isFrozen }));
+    }
+
 }
 
 const container = document.getElementById('root') as Element;

--- a/src/webview/memory-webview-view.tsx
+++ b/src/webview/memory-webview-view.tsx
@@ -107,7 +107,7 @@ class App extends React.Component<{}, MemoryAppState> {
                 updateTitle={this.updateTitle}
                 refreshMemory={this.refreshMemory}
                 toggleColumn={this.toggleColumn}
-                toggleFreezeButton={this.toggleFreezeButton}
+                toggleFrozen={this.toggleFrozen}
                 isFrozen={this.state.isFrozen}
                 fetchMemory={this.fetchMemory}
                 isMemoryFetching={this.state.isMemoryFetching}
@@ -185,8 +185,8 @@ class App extends React.Component<{}, MemoryAppState> {
         this.setState(prevState => ({ ...prevState, columns }));
     }
 
-    protected toggleFreezeButton = (): void => { this.doToggleFreezeButton(); };
-    protected doToggleFreezeButton(): void {
+    protected toggleFrozen = (): void => { this.doToggleFrozen(); };
+    protected doToggleFrozen(): void {
         this.setState(prevState => ({ ...prevState, isFrozen: !prevState.isFrozen }));
     }
 


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/blob/main/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Add a button in the title bar that allows to freeze the current content of the memory view. If the view is frozen, updates from the debug adapter are ignored and don't overwrite the shown data. In addition, UI elements that would trigger a data change (core options widget, `load more memory` buttons) are disabled.

Closes #70
#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Click the freeze-button (lock icon) in the title bar
- Core options widget (adress,offset lengh) and buttons to load more memory should become disabled
- Advanced display options are still enabled

Trigger memory updates (e.g by stepping in the debugger). Check that memory content remains unchanged

Unfreeze view and trigger updates. Memory content should update again.



#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
