### PR TITLE
Proposal: Use React context instead of prop drilling

### DIFF
--- a/src/webview/components/memory-app-provider.tsx
+++ b/src/webview/components/memory-app-provider.tsx
@@ -1,0 +1,199 @@
+/********************************************************************************
+ * Copyright (C) 2022 Ericsson, Arm and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { DebugProtocol } from '@vscode/debugprotocol';
+import React from 'react';
+import { HOST_EXTENSION } from 'vscode-messenger-common';
+import { logMessageType, readMemoryType, readyType, resetMemoryViewSettingsType, setMemoryViewSettingsType, setOptionsType, setTitleType } from '../../common/messaging';
+import { AddressColumn } from '../columns/address-column';
+import { AsciiColumn } from '../columns/ascii-column';
+import { ColumnStatus, columnContributionService } from '../columns/column-contribution-service';
+import { DataColumn } from '../columns/data-column';
+import { decorationService } from '../decorations/decoration-service';
+import { Decoration, Memory, MemoryDisplayConfiguration, MemoryState } from '../utils/view-types';
+import { variableDecorator } from '../variables/variable-decorations';
+import { messenger } from '../view-messenger';
+
+export interface MemoryAppState extends MemoryState, MemoryDisplayConfiguration {
+    title: string;
+    decorations: Decoration[];
+    columns: ColumnStatus[];
+    offset: number;
+}
+
+const MEMORY_DISPLAY_CONFIGURATION_DEFAULTS: MemoryDisplayConfiguration = {
+    bytesPerWord: 1,
+    wordsPerGroup: 1,
+    groupsPerRow: 4,
+    scrollingBehavior: 'Paginate',
+    addressRadix: 16,
+    showRadixPrefix: true,
+};
+
+const MEMORY_APP_STATE_DEFAULTS: MemoryAppState = {
+    title: 'Memory',
+    memory: undefined,
+    memoryReference: '',
+    offset: 0,
+    count: 256,
+    decorations: [],
+    columns: columnContributionService.getColumns(),
+    isMemoryFetching: false,
+    ...MEMORY_DISPLAY_CONFIGURATION_DEFAULTS
+};
+
+const MEMORY_APP_CONTEXT_DEFAULTS: MemoryAppContext = {
+    ...MEMORY_APP_STATE_DEFAULTS,
+    updateMemoryState: () => { },
+    updateMemoryDisplayConfiguration: () => { },
+    resetMemoryDisplayConfiguration: () => { },
+    updateTitle: () => { },
+    refreshMemory: () => { },
+    fetchMemory: async () => { },
+    toggleColumn: () => { }
+};
+
+export const MemoryAppContext = React.createContext<MemoryAppContext>(MEMORY_APP_CONTEXT_DEFAULTS);
+
+export interface MemoryAppContext extends MemoryAppState {
+    updateMemoryState: (newState: Partial<MemoryAppState>) => void;
+    updateMemoryDisplayConfiguration: (newState: Partial<MemoryDisplayConfiguration>) => void;
+    resetMemoryDisplayConfiguration: () => void;
+    updateTitle: (title: string) => void;
+    refreshMemory: () => void;
+    fetchMemory: (partialOptions?: Partial<DebugProtocol.ReadMemoryArguments>) => Promise<void>;
+    toggleColumn: (id: string, active: boolean) => void;
+}
+
+interface MemoryAppProviderProps {
+    children: React.ReactNode;
+}
+
+export class MemoryAppProvider extends React.Component<MemoryAppProviderProps, MemoryAppState> {
+
+    public constructor(props: MemoryAppProviderProps) {
+        super(props);
+        columnContributionService.register(new AddressColumn(), false);
+        columnContributionService.register(new DataColumn(), false);
+        columnContributionService.register(variableDecorator);
+        columnContributionService.register(new AsciiColumn());
+        decorationService.register(variableDecorator);
+        this.state = {
+            title: 'Memory',
+            memory: undefined,
+            memoryReference: '',
+            offset: 0,
+            count: 256,
+            decorations: [],
+            columns: columnContributionService.getColumns(),
+            isMemoryFetching: false,
+            ...MEMORY_DISPLAY_CONFIGURATION_DEFAULTS
+        };
+    }
+
+    public componentDidMount(): void {
+        messenger.onRequest(setOptionsType, options => this.setOptions(options));
+        messenger.onNotification(setMemoryViewSettingsType, config => {
+            for (const column of columnContributionService.getColumns()) {
+                const id = column.contribution.id;
+                const configurable = column.configurable;
+                this.toggleColumn(id, !configurable || !!config.visibleColumns?.includes(id));
+            }
+            this.setState(prevState => ({ ...prevState, ...config, title: config.title ?? prevState.title, }));
+        });
+        messenger.sendNotification(readyType, HOST_EXTENSION, undefined);
+    }
+
+    public render(): React.ReactNode {
+        const contextValue: MemoryAppContext = {
+            ...this.state,
+            updateMemoryState: this.updateMemoryState,
+            fetchMemory: this.fetchMemory,
+            refreshMemory: this.refreshMemory,
+            resetMemoryDisplayConfiguration: this.resetMemoryDisplayConfiguration,
+            toggleColumn: this.toggleColumn,
+            updateMemoryDisplayConfiguration: this.updateMemoryDisplayConfiguration,
+            updateTitle: this.updateTitle
+        };
+
+        return (
+            <MemoryAppContext.Provider value={contextValue}>
+                {this.props.children}
+            </MemoryAppContext.Provider>
+        );
+    }
+
+    protected updateMemoryState = (newState: Partial<MemoryState>) => this.setState(prevState => ({ ...prevState, ...newState }));
+    protected updateMemoryDisplayConfiguration = (newState: Partial<MemoryDisplayConfiguration>) => this.setState(prevState => ({ ...prevState, ...newState }));
+    protected resetMemoryDisplayConfiguration = () => messenger.sendNotification(resetMemoryViewSettingsType, HOST_EXTENSION, undefined);
+    protected updateTitle = (title: string) => {
+        this.setState({ title });
+        messenger.sendNotification(setTitleType, HOST_EXTENSION, title);
+    };
+
+    protected async setOptions(options?: Partial<DebugProtocol.ReadMemoryArguments>): Promise<void> {
+        messenger.sendRequest(logMessageType, HOST_EXTENSION, `Setting options: ${JSON.stringify(options)}`);
+        this.setState(prevState => ({ ...prevState, ...options }));
+        return this.fetchMemory(options);
+    }
+
+    protected refreshMemory = () => { this.fetchMemory(); };
+
+    protected fetchMemory = async (partialOptions?: Partial<DebugProtocol.ReadMemoryArguments>): Promise<void> => this.doFetchMemory(partialOptions);
+    protected async doFetchMemory(partialOptions?: Partial<DebugProtocol.ReadMemoryArguments>): Promise<void> {
+        this.setState(prev => ({ ...prev, isMemoryFetching: true }));
+        const completeOptions = {
+            memoryReference: partialOptions?.memoryReference || this.state.memoryReference,
+            offset: partialOptions?.offset ?? this.state.offset,
+            count: partialOptions?.count ?? this.state.count
+        };
+
+        try {
+            const response = await messenger.sendRequest(readMemoryType, HOST_EXTENSION, completeOptions);
+            await Promise.all(Array.from(
+                new Set(columnContributionService.getUpdateExecutors().concat(decorationService.getUpdateExecutors())),
+                executor => executor.fetchData(completeOptions)
+            ));
+
+            this.setState({
+                decorations: decorationService.decorations,
+                memory: this.convertMemory(response),
+                memoryReference: completeOptions.memoryReference,
+                offset: completeOptions.offset,
+                count: completeOptions.count,
+                isMemoryFetching: false
+            });
+
+            messenger.sendRequest(setOptionsType, HOST_EXTENSION, completeOptions);
+        } finally {
+            this.setState(prev => ({ ...prev, isMemoryFetching: false }));
+        }
+
+    }
+
+    protected convertMemory(result: DebugProtocol.ReadMemoryResponse['body']): Memory {
+        if (!result?.data) { throw new Error('No memory provided!'); }
+        const address = BigInt(result.address);
+        const bytes = Uint8Array.from(Buffer.from(result.data, 'base64'));
+        return { bytes, address };
+    }
+
+    protected toggleColumn = (id: string, active: boolean): void => { this.doToggleColumn(id, active); };
+    protected async doToggleColumn(id: string, isVisible: boolean): Promise<void> {
+        const columns = isVisible ? await columnContributionService.show(id, this.state) : columnContributionService.hide(id);
+        this.setState(prevState => ({ ...prevState, columns }));
+    }
+}

--- a/src/webview/components/memory-widget.tsx
+++ b/src/webview/components/memory-widget.tsx
@@ -14,30 +14,11 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { DebugProtocol } from '@vscode/debugprotocol';
 import React from 'react';
-import { ColumnStatus } from '../columns/column-contribution-service';
-import { Decoration, Endianness, Memory, MemoryDisplayConfiguration } from '../utils/view-types';
+import { Endianness } from '../utils/view-types';
+import { MemoryAppContext } from './memory-app-provider';
 import { MemoryTable } from './memory-table';
 import { OptionsWidget } from './options-widget';
-
-interface MemoryWidgetProps extends MemoryDisplayConfiguration {
-    memory?: Memory;
-    title: string;
-    decorations: Decoration[];
-    columns: ColumnStatus[];
-    memoryReference: string;
-    offset: number;
-    count: number;
-    isMemoryFetching: boolean;
-    refreshMemory: () => void;
-    updateMemoryArguments: (memoryArguments: Partial<DebugProtocol.ReadMemoryArguments>) => void;
-    toggleColumn(id: string, active: boolean): void;
-    updateMemoryDisplayConfiguration: (memoryArguments: Partial<MemoryDisplayConfiguration>) => void;
-    resetMemoryDisplayConfiguration: () => void;
-    updateTitle: (title: string) => void;
-    fetchMemory(partialOptions?: Partial<DebugProtocol.ReadMemoryArguments>): Promise<void>
-}
 
 interface MemoryWidgetState {
     endianness: Endianness;
@@ -47,48 +28,21 @@ const defaultOptions: MemoryWidgetState = {
     endianness: Endianness.Little,
 };
 
-export class MemoryWidget extends React.Component<MemoryWidgetProps, MemoryWidgetState> {
-    constructor(props: MemoryWidgetProps) {
+export class MemoryWidget extends React.Component<{}, MemoryWidgetState> {
+    static contextType = MemoryAppContext;
+    declare context: MemoryAppContext;
+
+    constructor(props: {}) {
         super(props);
         this.state = { ...defaultOptions };
     }
 
     override render(): React.ReactNode {
         return (<div className='flex flex-column h-full'>
-            <OptionsWidget
-                title={this.props.title}
-                updateTitle={this.props.updateTitle}
-                columnOptions={this.props.columns}
-                memoryReference={this.props.memoryReference}
-                offset={this.props.offset}
-                count={this.props.count}
-                endianness={this.state.endianness}
-                bytesPerWord={this.props.bytesPerWord}
-                wordsPerGroup={this.props.wordsPerGroup}
-                groupsPerRow={this.props.groupsPerRow}
-                updateMemoryArguments={this.props.updateMemoryArguments}
-                updateRenderOptions={this.props.updateMemoryDisplayConfiguration}
-                resetRenderOptions={this.props.resetMemoryDisplayConfiguration}
-                refreshMemory={this.props.refreshMemory}
-                addressRadix={this.props.addressRadix}
-                showRadixPrefix={this.props.showRadixPrefix}
-                toggleColumn={this.props.toggleColumn}
-            />
+            <OptionsWidget endianness={this.state.endianness} />
             <MemoryTable
-                decorations={this.props.decorations}
-                columnOptions={this.props.columns.filter(candidate => candidate.active)}
-                memory={this.props.memory}
                 endianness={this.state.endianness}
-                bytesPerWord={this.props.bytesPerWord}
-                wordsPerGroup={this.props.wordsPerGroup}
-                groupsPerRow={this.props.groupsPerRow}
-                offset={this.props.offset}
-                count={this.props.count}
-                fetchMemory={this.props.fetchMemory}
-                isMemoryFetching={this.props.isMemoryFetching}
-                scrollingBehavior={this.props.scrollingBehavior}
-                addressRadix={this.props.addressRadix}
-                showRadixPrefix={this.props.showRadixPrefix}
+                columnOptions={this.context.columns.filter(candidate => candidate.active)}
             />
         </div>);
     }

--- a/src/webview/memory-webview-view.tsx
+++ b/src/webview/memory-webview-view.tsx
@@ -14,170 +14,20 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+import 'primeflex/primeflex.css';
+import { PrimeReactProvider } from 'primereact/api';
 import React from 'react';
 import { createRoot } from 'react-dom/client';
-import { HOST_EXTENSION } from 'vscode-messenger-common';
-import {
-    readyType,
-    logMessageType,
-    setOptionsType,
-    readMemoryType,
-    setTitleType,
-    setMemoryViewSettingsType,
-    resetMemoryViewSettingsType,
-} from '../common/messaging';
-import type { DebugProtocol } from '@vscode/debugprotocol';
-import { Decoration, Memory, MemoryDisplayConfiguration, MemoryState } from './utils/view-types';
 import { MemoryWidget } from './components/memory-widget';
-import { messenger } from './view-messenger';
-import { ColumnStatus, columnContributionService } from './columns/column-contribution-service';
-import { decorationService } from './decorations/decoration-service';
-import { variableDecorator } from './variables/variable-decorations';
-import { AsciiColumn } from './columns/ascii-column';
-import { AddressColumn } from './columns/address-column';
-import { DataColumn } from './columns/data-column';
-import { PrimeReactProvider } from 'primereact/api';
-import 'primeflex/primeflex.css';
+import { MemoryAppProvider } from './components/memory-app-provider';
 
-export interface MemoryAppState extends MemoryState, MemoryDisplayConfiguration {
-    title: string;
-    decorations: Decoration[];
-    columns: ColumnStatus[];
-}
-
-const MEMORY_DISPLAY_CONFIGURATION_DEFAULTS: MemoryDisplayConfiguration = {
-    bytesPerWord: 1,
-    wordsPerGroup: 1,
-    groupsPerRow: 4,
-    scrollingBehavior: 'Paginate',
-    addressRadix: 16,
-    showRadixPrefix: true,
-};
-
-class App extends React.Component<{}, MemoryAppState> {
-
-    public constructor(props: {}) {
-        super(props);
-        columnContributionService.register(new AddressColumn(), false);
-        columnContributionService.register(new DataColumn(), false);
-        columnContributionService.register(variableDecorator);
-        columnContributionService.register(new AsciiColumn());
-        decorationService.register(variableDecorator);
-        this.state = {
-            title: 'Memory',
-            memory: undefined,
-            memoryReference: '',
-            offset: 0,
-            count: 256,
-            decorations: [],
-            columns: columnContributionService.getColumns(),
-            isMemoryFetching: false,
-            ...MEMORY_DISPLAY_CONFIGURATION_DEFAULTS
-        };
-    }
-
-    public componentDidMount(): void {
-        messenger.onRequest(setOptionsType, options => this.setOptions(options));
-        messenger.onNotification(setMemoryViewSettingsType, config => {
-            for (const column of columnContributionService.getColumns()) {
-                const id = column.contribution.id;
-                const configurable = column.configurable;
-                this.toggleColumn(id, !configurable || !!config.visibleColumns?.includes(id));
-            }
-            this.setState(prevState => ({ ...prevState, ...config, title: config.title ?? prevState.title, }));
-        });
-        messenger.sendNotification(readyType, HOST_EXTENSION, undefined);
-    }
-
-    public render(): React.ReactNode {
-        return <PrimeReactProvider>
-            <MemoryWidget
-                memory={this.state.memory}
-                decorations={this.state.decorations}
-                columns={this.state.columns}
-                memoryReference={this.state.memoryReference}
-                offset={this.state.offset ?? 0}
-                count={this.state.count}
-                title={this.state.title}
-                updateMemoryArguments={this.updateMemoryState}
-                updateMemoryDisplayConfiguration={this.updateMemoryDisplayConfiguration}
-                resetMemoryDisplayConfiguration={this.resetMemoryDisplayConfiguration}
-                updateTitle={this.updateTitle}
-                refreshMemory={this.refreshMemory}
-                toggleColumn={this.toggleColumn}
-                fetchMemory={this.fetchMemory}
-                isMemoryFetching={this.state.isMemoryFetching}
-                bytesPerWord={this.state.bytesPerWord}
-                groupsPerRow={this.state.groupsPerRow}
-                wordsPerGroup={this.state.wordsPerGroup}
-                scrollingBehavior={this.state.scrollingBehavior}
-                addressRadix={this.state.addressRadix}
-                showRadixPrefix={this.state.showRadixPrefix}
-            />
-        </PrimeReactProvider>;
-    }
-
-    protected updateMemoryState = (newState: Partial<MemoryState>) => this.setState(prevState => ({ ...prevState, ...newState }));
-    protected updateMemoryDisplayConfiguration = (newState: Partial<MemoryDisplayConfiguration>) => this.setState(prevState => ({ ...prevState, ...newState }));
-    protected resetMemoryDisplayConfiguration = () => messenger.sendNotification(resetMemoryViewSettingsType, HOST_EXTENSION, undefined);
-    protected updateTitle = (title: string) => {
-        this.setState({ title });
-        messenger.sendNotification(setTitleType, HOST_EXTENSION, title);
-    };
-
-    protected async setOptions(options?: Partial<DebugProtocol.ReadMemoryArguments>): Promise<void> {
-        messenger.sendRequest(logMessageType, HOST_EXTENSION, `Setting options: ${JSON.stringify(options)}`);
-        this.setState(prevState => ({ ...prevState, ...options }));
-        return this.fetchMemory(options);
-    }
-
-    protected refreshMemory = () => { this.fetchMemory(); };
-
-    protected fetchMemory = async (partialOptions?: Partial<DebugProtocol.ReadMemoryArguments>): Promise<void> => this.doFetchMemory(partialOptions);
-    protected async doFetchMemory(partialOptions?: Partial<DebugProtocol.ReadMemoryArguments>): Promise<void> {
-        this.setState(prev => ({ ...prev, isMemoryFetching: true }));
-        const completeOptions = {
-            memoryReference: partialOptions?.memoryReference || this.state.memoryReference,
-            offset: partialOptions?.offset ?? this.state.offset,
-            count: partialOptions?.count ?? this.state.count
-        };
-
-        try {
-            const response = await messenger.sendRequest(readMemoryType, HOST_EXTENSION, completeOptions);
-            await Promise.all(Array.from(
-                new Set(columnContributionService.getUpdateExecutors().concat(decorationService.getUpdateExecutors())),
-                executor => executor.fetchData(completeOptions)
-            ));
-
-            this.setState({
-                decorations: decorationService.decorations,
-                memory: this.convertMemory(response),
-                memoryReference: completeOptions.memoryReference,
-                offset: completeOptions.offset,
-                count: completeOptions.count,
-                isMemoryFetching: false
-            });
-
-            messenger.sendRequest(setOptionsType, HOST_EXTENSION, completeOptions);
-        } finally {
-            this.setState(prev => ({ ...prev, isMemoryFetching: false }));
-        }
-
-    }
-
-    protected convertMemory(result: DebugProtocol.ReadMemoryResponse['body']): Memory {
-        if (!result?.data) { throw new Error('No memory provided!'); }
-        const address = BigInt(result.address);
-        const bytes = Uint8Array.from(Buffer.from(result.data, 'base64'));
-        return { bytes, address };
-    }
-
-    protected toggleColumn = (id: string, active: boolean): void => { this.doToggleColumn(id, active); };
-    protected async doToggleColumn(id: string, isVisible: boolean): Promise<void> {
-        const columns = isVisible ? await columnContributionService.show(id, this.state) : columnContributionService.hide(id);
-        this.setState(prevState => ({ ...prevState, columns }));
-    }
-}
+const App = () => (
+    <MemoryAppProvider>
+        <PrimeReactProvider>
+            <MemoryWidget />
+        </PrimeReactProvider>
+    </MemoryAppProvider>
+);
 
 const container = document.getElementById('root') as Element;
 createRoot(container).render(<App />);


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/blob/main/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
- Refactor  app component  logic into a context provider 
- Wrap  the root component into the newly created `MemoryAppProvider`. This way child components can access the central state via context API and props drilling is no longer required.
- Refactor child components to access the central state info via `context` instead of props.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Full feature testing of the webview is required to ensure that everything works as before.
#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
