### PR TITLE
Reset tree tracking when scopes response received

### DIFF
--- a/src/plugin/adapter-registry/adapter-capabilities.ts
+++ b/src/plugin/adapter-registry/adapter-capabilities.ts
@@ -54,6 +54,7 @@ export class AdapterVariableTracker implements vscode.DebugAdapterTracker {
     /** Produces a two-level tree of scopes and their immediate children. Does not handle expansion of complex variables. */
     onDidSendMessage(message: unknown): void {
         if (isScopesResponse(message)) {
+            this.variablesTree = {}; // Scopes request implies that all scopes will be queried again.
             for (const scope of message.body.scopes) {
                 if (this.isDesiredScope(scope)) {
                     if (!this.variablesTree[scope.variablesReference] || this.variablesTree[scope.variablesReference].name !== scope.name) {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/blob/main/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The code for tracking variables would sometimes report variables multiple times if the `variablesReference` value for a given scope (e.g. 'Locals') changed.

![image](https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/assets/62660806/9cba0806-4d13-41e9-970b-02466c138395)

This PR adjusts the handling to clear the tree when the response to the `scopes` request is received: that request implies that all scopes will be refreshed (possible with different `variablesReference` values), so that whatever old data is available locally is (possibly) invalid.

> NB: we'll have some work coming in from @WyoTwT that will make the variable retrieval for Memory Inspector views independent of the routine fetching for a debug session.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Debug a program (e.g. with the CDT GDB adapter)
2. Load the memory view with variables visible.
3. Step a number of times (e.g. through a loop)
4. Observe that a given variable only appears once in the variables column.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
