### PR TITLE
Make memory address padding configurable

### DIFF
--- a/package.json
+++ b/package.json
@@ -184,7 +184,10 @@
           "description": "Default words per group"
         },
         "memory-inspector.groupings.groupsPerRow": {
-          "type": ["string", "number"],
+          "type": [
+            "string",
+            "number"
+          ],
           "enum": [
             "Autofit",
             1,
@@ -230,10 +233,10 @@
           ],
           "default": "Minimal",
           "enumDescriptions": [
-            "Minimal padding based on the longest address in range.",
-            "Disables padding, presenting addresses as-is.",
-            "Pads addresses to fit within a 32-bit address space.",
-            "Pads addresses to fit within a 64-bit address space."
+            "Pads to largest address width in loaded range.",
+            "Disables padding.",
+            "Pads to 32 bits.",
+            "Pads to 64 bits."
           ],
           "description": "Controls the padding with 0s for memory addresses, enhancing readability by aligning them within a specified bit-width context."
         },

--- a/package.json
+++ b/package.json
@@ -220,6 +220,23 @@
           ],
           "description": "Behavior when adding more memory beyond the current view."
         },
+        "memory-inspector.addressPadding": {
+          "type": "string",
+          "enum": [
+            "Minimal",
+            "Unpadded",
+            "32bit",
+            "64bit"
+          ],
+          "default": "Minimal",
+          "enumDescriptions": [
+            "Minimal padding based on the longest address in range.",
+            "Disables padding, presenting addresses as-is.",
+            "Pads addresses to fit within a 32-bit address space.",
+            "Pads addresses to fit within a 64-bit address space."
+          ],
+          "description": "Controls the padding with 0s for memory addresses, enhancing readability by aligning them within a specified bit-width context."
+        },
         "memory-inspector.addressRadix": {
           "type": "number",
           "enum": [

--- a/src/common/memory-range.ts
+++ b/src/common/memory-range.ts
@@ -85,9 +85,12 @@ export function getRadixMarker(radix: Radix): string {
     return radixPrefixMap[radix];
 }
 
-export function getAddressString(address: bigint, radix: Radix, architecture: Architecture = 32, addPadding = false): string {
-    const paddedLength = addPadding ? Math.ceil(architecture / Math.log2(radix)) : 0;
+export function getAddressString(address: bigint, radix: Radix, paddedLength: number = 0): string {
     return address.toString(radix).padStart(paddedLength, '0');
+}
+
+export function getAddressLength(padding: number, radix: Radix): number {
+    return Math.ceil(padding / Math.log2(radix));
 }
 
 export function toHexStringWithRadixMarker(target: bigint): string {

--- a/src/plugin/manifest.ts
+++ b/src/plugin/manifest.ts
@@ -48,6 +48,8 @@ export const DEFAULT_GROUPS_PER_ROW: GroupsPerRowOption = 4;
 // Scroll
 export const CONFIG_SCROLLING_BEHAVIOR = 'scrollingBehavior';
 export const DEFAULT_SCROLLING_BEHAVIOR = 'Paginate';
+export const CONFIG_ADDRESS_PADDING = 'addressPadding';
+export const DEFAULT_ADDRESS_PADDING = 'Minimal';
 export const CONFIG_ADDRESS_RADIX = 'addressRadix';
 export const DEFAULT_ADDRESS_RADIX = 16;
 export const CONFIG_SHOW_RADIX_PREFIX = 'showRadixPrefix';

--- a/src/plugin/memory-webview-main.ts
+++ b/src/plugin/memory-webview-main.ts
@@ -35,7 +35,7 @@ import {
 import { MemoryProvider } from './memory-provider';
 import { outputChannelLogger } from './logger';
 import { VariableRange } from '../common/memory-range';
-import { MemoryViewSettings, ScrollingBehavior } from '../webview/utils/view-types';
+import { AddressPaddingOptions, MemoryViewSettings, ScrollingBehavior } from '../webview/utils/view-types';
 
 interface Variable {
     name: string;
@@ -225,9 +225,10 @@ export class MemoryWebview implements vscode.CustomReadonlyEditorProvider {
         const visibleColumns = CONFIGURABLE_COLUMNS
             .filter(column => vscode.workspace.getConfiguration(manifest.PACKAGE_NAME).get<boolean>(column, false))
             .map(columnId => columnId.replace('columns.', ''));
+        const addressPadding = AddressPaddingOptions[memoryInspectorConfiguration.get(manifest.CONFIG_ADDRESS_PADDING, manifest.DEFAULT_ADDRESS_PADDING)];
         const addressRadix = memoryInspectorConfiguration.get<number>(manifest.CONFIG_ADDRESS_RADIX, manifest.DEFAULT_ADDRESS_RADIX);
         const showRadixPrefix = memoryInspectorConfiguration.get<boolean>(manifest.CONFIG_SHOW_RADIX_PREFIX, manifest.DEFAULT_SHOW_RADIX_PREFIX);
-        return { title, bytesPerWord, wordsPerGroup, groupsPerRow, scrollingBehavior, visibleColumns, addressRadix, showRadixPrefix };
+        return { title, bytesPerWord, wordsPerGroup, groupsPerRow, scrollingBehavior, visibleColumns, addressPadding, addressRadix, showRadixPrefix };
     }
 
     protected async readMemory(request: DebugProtocol.ReadMemoryArguments): Promise<MemoryReadResult> {

--- a/src/webview/columns/address-column.tsx
+++ b/src/webview/columns/address-column.tsx
@@ -16,8 +16,8 @@
 
 import React, { ReactNode } from 'react';
 import { BigIntMemoryRange, getAddressString, getRadixMarker } from '../../common/memory-range';
-import { ColumnContribution, ColumnFittingType } from './column-contribution-service';
-import { Memory, MemoryDisplayConfiguration } from '../utils/view-types';
+import { ColumnContribution, ColumnFittingType, TableRenderOptions } from './column-contribution-service';
+import { Memory } from '../utils/view-types';
 
 export class AddressColumn implements ColumnContribution {
     static ID = 'address';
@@ -28,10 +28,10 @@ export class AddressColumn implements ColumnContribution {
 
     fittingType: ColumnFittingType = 'content-width';
 
-    render(range: BigIntMemoryRange, _: Memory, options: MemoryDisplayConfiguration): ReactNode {
+    render(range: BigIntMemoryRange, _: Memory, options: TableRenderOptions): ReactNode {
         return <span className='memory-start-address'>
             {options.showRadixPrefix && <span className='radix-prefix'>{getRadixMarker(options.addressRadix)}</span>}
-            <span className='address'>{getAddressString(range.startAddress, options.addressRadix)}</span>
+            <span className='address'>{getAddressString(range.startAddress, options.addressRadix, options.effectiveAddressLength)}</span>
         </span>;
     }
 }

--- a/src/webview/components/memory-table.tsx
+++ b/src/webview/components/memory-table.tsx
@@ -101,6 +101,7 @@ interface MemoryTableProps extends TableRenderOptions, MemoryDisplayConfiguratio
     decorations: Decoration[];
     offset: number;
     count: number;
+    effectiveAddressLength: number;
     fetchMemory(partialOptions?: Partial<DebugProtocol.ReadMemoryArguments>): Promise<void>;
     isMemoryFetching: boolean;
     isFrozen: boolean;

--- a/src/webview/components/memory-widget.tsx
+++ b/src/webview/components/memory-widget.tsx
@@ -29,6 +29,7 @@ interface MemoryWidgetProps extends MemoryDisplayConfiguration {
     memoryReference: string;
     offset: number;
     count: number;
+    effectiveAddressLength: number;
     isMemoryFetching: boolean;
     refreshMemory: () => void;
     updateMemoryArguments: (memoryArguments: Partial<DebugProtocol.ReadMemoryArguments>) => void;
@@ -72,6 +73,7 @@ export class MemoryWidget extends React.Component<MemoryWidgetProps, MemoryWidge
                 updateRenderOptions={this.props.updateMemoryDisplayConfiguration}
                 resetRenderOptions={this.props.resetMemoryDisplayConfiguration}
                 refreshMemory={this.props.refreshMemory}
+                addressPadding={this.props.addressPadding}
                 addressRadix={this.props.addressRadix}
                 showRadixPrefix={this.props.showRadixPrefix}
                 toggleColumn={this.props.toggleColumn}
@@ -88,9 +90,11 @@ export class MemoryWidget extends React.Component<MemoryWidgetProps, MemoryWidge
                 groupsPerRow={this.props.groupsPerRow}
                 offset={this.props.offset}
                 count={this.props.count}
+                effectiveAddressLength={this.props.effectiveAddressLength}
                 fetchMemory={this.props.fetchMemory}
                 isMemoryFetching={this.props.isMemoryFetching}
                 scrollingBehavior={this.props.scrollingBehavior}
+                addressPadding={this.props.addressPadding}
                 addressRadix={this.props.addressRadix}
                 showRadixPrefix={this.props.showRadixPrefix}
                 isFrozen={this.props.isFrozen}

--- a/src/webview/components/options-widget.tsx
+++ b/src/webview/components/options-widget.tsx
@@ -23,16 +23,14 @@ import { OverlayPanel } from 'primereact/overlaypanel';
 import { classNames } from 'primereact/utils';
 import React, { FocusEventHandler, KeyboardEvent, KeyboardEventHandler, MouseEventHandler } from 'react';
 import { TableRenderOptions } from '../columns/column-contribution-service';
-import {
-    SerializedTableRenderOptions,
-} from '../utils/view-types';
+import { AddressPaddingOptions, SerializedTableRenderOptions } from '../utils/view-types';
 import { MultiSelectWithLabel } from './multi-select';
 import { CONFIG_BYTES_PER_WORD_CHOICES, CONFIG_GROUPS_PER_ROW_CHOICES, CONFIG_WORDS_PER_GROUP_CHOICES } from '../../plugin/manifest';
 import { tryToNumber } from '../../common/typescript';
 import { Checkbox } from 'primereact/checkbox';
 
 export interface OptionsWidgetProps
-    extends Omit<TableRenderOptions, 'scrollingBehavior'>,
+    extends Omit<TableRenderOptions, 'scrollingBehavior' | 'effectiveAddressLength'>,
     Required<DebugProtocol.ReadMemoryArguments> {
     title: string;
     updateRenderOptions: (options: Partial<SerializedTableRenderOptions>) => void;
@@ -58,6 +56,7 @@ const enum InputId {
     BytesPerWord = 'word-size',
     WordsPerGroup = 'words-per-group',
     GroupsPerRow = 'groups-per-row',
+    AddressPadding = 'address-padding',
     AddressRadix = 'address-radix',
     ShowRadixPrefix = 'show-radix-prefix',
 }
@@ -321,6 +320,20 @@ export class OptionsWidget extends React.Component<OptionsWidgetProps, OptionsWi
                                 className='advanced-options-dropdown' />
 
                             <h2>Address Format</h2>
+
+                            <label
+                                htmlFor={InputId.AddressPadding}
+                                className='advanced-options-label'
+                            >
+                                Address Padding
+                            </label>
+                            <Dropdown
+                                id={InputId.AddressPadding}
+                                value={this.props.addressPadding}
+                                onChange={this.handleAdvancedOptionsDropdownChange}
+                                options={Object.entries(AddressPaddingOptions).map(([label, value]) => ({ label, value }))}
+                                className="advanced-options-dropdown" />
+
                             <label
                                 htmlFor={InputId.AddressRadix}
                                 className='advanced-options-label'
@@ -415,6 +428,9 @@ export class OptionsWidget extends React.Component<OptionsWidgetProps, OptionsWi
                 break;
             case InputId.GroupsPerRow:
                 this.props.updateRenderOptions({ groupsPerRow: tryToNumber(value) ?? value });
+                break;
+            case InputId.AddressPadding:
+                this.props.updateRenderOptions({ addressPadding: value });
                 break;
             case InputId.AddressRadix:
                 this.props.updateRenderOptions({ addressRadix: Number(value) });

--- a/src/webview/memory-webview-view.tsx
+++ b/src/webview/memory-webview-view.tsx
@@ -100,7 +100,10 @@ class App extends React.Component<{}, MemoryAppState> {
             (this.state.addressPadding === 'Min' && this.state.memory !== prevState.memory)
             || this.state.addressPadding !== prevState.addressPadding;
         if (addressPaddingNeedsUpdate) {
-            this.setState({ effectiveAddressLength: this.getEffectiveAddressLength(this.state.memory), });
+            const effectiveAddressLength = this.getEffectiveAddressLength(this.state.memory);
+            if (this.state.effectiveAddressLength !== effectiveAddressLength) {
+                this.setState({ effectiveAddressLength });
+            }
         }
     }
 

--- a/src/webview/memory-webview-view.tsx
+++ b/src/webview/memory-webview-view.tsx
@@ -205,7 +205,7 @@ class App extends React.Component<{}, MemoryAppState> {
     }
 
     protected getLastAddressLength(memory?: Memory): number {
-        if (memory === undefined) {
+        if (memory === undefined || this.state.groupsPerRow === 'Autofit') {
             return 0;
         }
         const rowLength = this.state.bytesPerWord * this.state.wordsPerGroup * this.state.groupsPerRow;

--- a/src/webview/utils/view-types.ts
+++ b/src/webview/utils/view-types.ts
@@ -33,7 +33,7 @@ export interface Memory {
 export interface SerializedTableRenderOptions extends MemoryDisplayConfiguration {
     columnOptions: Array<{ label: string, doRender: boolean }>;
     endianness: Endianness;
-    bytesPerWord: number;
+    effectiveAddressLength: number;
 }
 
 export interface Event<T> {
@@ -84,10 +84,19 @@ export interface MemoryDisplayConfiguration {
     wordsPerGroup: number;
     groupsPerRow: GroupsPerRowOption;
     scrollingBehavior: ScrollingBehavior;
+    addressPadding: AddressPadding;
     addressRadix: Radix;
     showRadixPrefix: boolean;
 }
 export type ScrollingBehavior = 'Paginate' | 'Infinite';
+
+export type AddressPadding = 'Min' | number;
+export const AddressPaddingOptions = {
+    'Minimal': 'Min',
+    'Unpadded': 0,
+    '32bit': 32,
+    '64bit': 64,
+} as const;
 
 export interface ColumnVisibilityStatus {
     visibleColumns: string[];


### PR DESCRIPTION
#### What it does

Introduces VS Code setting for memory address padding with the values
  * Unpadded
  * Minimal padding
  * 32 bit padding
  * 64 bit padding

Fixes #76

#### How to test

* Open memory a inspector instance and switch address padding in the options
* Observe whether the memory address is adjusted accordingly
* Change setting `memory-inspector.addressPadding` in VS Code settings
* Open new memory inspector view and ensure the new padding setting is used
* Change VS Code setting again and reset options in memory view to check if it resets properly

https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/assets/588090/aaef0634-aa12-44ad-991f-1f55f70416f5

#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
