### PR TITLE
Improve styling of column resize handles

### DIFF
--- a/media/memory-table.css
+++ b/media/memory-table.css
@@ -81,3 +81,19 @@
 .radix-prefix {
   opacity: 0.6;
 }
+
+/* == Resize Handle == */
+
+.memory-inspector-table span.p-column-resizer {
+  border-right: 2px solid var(--vscode-editor-lineHighlightBorder);
+  transition: border-right .1s ease-out;
+}
+
+.memory-inspector-table span.p-column-resizer:hover {
+  border-right: 2px solid var(--vscode-sash-hoverBorder);
+}
+
+.memory-inspector-table .p-column-resizer-helper {
+  margin-top: 32px !important; /* avoid overlap with top 'Load more' widget */
+  width: 2px;
+}


### PR DESCRIPTION
#### What it does
- Only show resize divider on table header
- Use same color for resize divider as for dividers of data

![resize-handles](https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/assets/19170971/1eaebd64-a68a-4a41-b080-11705a3769a6)

Closes #71

#### How to test
- Start up any memory inspector and try it out ;-)

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
