### PR TITLE
Support storing and applying of memory content

### DIFF
--- a/media/options-widget.css
+++ b/media/options-widget.css
@@ -35,10 +35,11 @@
   flex-grow: 1;
 }
 
+.memory-options-widget .p-button {
+  align-self: end;
+}
+
 .memory-options-widget .edit-label-toggle {
-  position: absolute;
-  right: 24px;
-  top: 8px;
   opacity: 0;
   transition: opacity 0.2s;
 }

--- a/package.json
+++ b/package.json
@@ -113,11 +113,13 @@
       {
         "command": "memory-inspector.store-file",
         "title": "Store Memory as File",
+        "enablement": "memory-inspector.canRead",
         "category": "Memory"
       },
       {
         "command": "memory-inspector.apply-file",
         "title": "Apply Memory from File",
+        "enablement": "memory-inspector.canWrite",
         "category": "Memory"
       }
     ],
@@ -132,12 +134,10 @@
           "when": "false"
         },
         {
-          "command": "memory-inspector.store-file",
-          "when": "memory-inspector.canRead"
+          "command": "memory-inspector.store-file"
         },
         {
-          "command": "memory-inspector.apply-file",
-          "when": "memory-inspector.canWrite"
+          "command": "memory-inspector.apply-file"
         }
       ],
       "debug/variables/context": [

--- a/package.json
+++ b/package.json
@@ -37,13 +37,15 @@
     "formik": "^2.4.5",
     "lodash": "^4.17.21",
     "memoize-one": "^6.0.0",
+    "nrf-intel-hex": "^1.4.0",
     "primeflex": "^3.3.1",
     "primereact": "^10.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "vscode-messenger": "^0.4.3",
     "vscode-messenger-common": "^0.4.3",
-    "vscode-messenger-webview": "^0.4.3"
+    "vscode-messenger-webview": "^0.4.3",
+    "vscode-uri": "^3.0.8"
   },
   "devDependencies": {
     "@types/lodash": "^4.14.202",
@@ -107,6 +109,16 @@
         "title": "Advanced Display Options",
         "category": "Memory",
         "enablement": "webviewId === memory-inspector.memory"
+      },
+      {
+        "command": "memory-inspector.store-file",
+        "title": "Store Memory as File",
+        "category": "Memory"
+      },
+      {
+        "command": "memory-inspector.apply-file",
+        "title": "Apply Memory from File",
+        "category": "Memory"
       }
     ],
     "menus": {
@@ -118,11 +130,23 @@
         {
           "command": "memory-inspector.show-variable",
           "when": "false"
+        },
+        {
+          "command": "memory-inspector.store-file",
+          "when": "memory-inspector.canRead"
+        },
+        {
+          "command": "memory-inspector.apply-file",
+          "when": "memory-inspector.canWrite"
         }
       ],
       "debug/variables/context": [
         {
           "command": "memory-inspector.show-variable",
+          "when": "canViewMemory && memory-inspector.canRead"
+        },
+        {
+          "command": "memory-inspector.store-file",
           "when": "canViewMemory && memory-inspector.canRead"
         }
       ],
@@ -130,6 +154,20 @@
         {
           "command": "memory-inspector.show-variable",
           "when": "canViewMemory && memory-inspector.canRead"
+        }
+      ],
+      "explorer/context": [
+        {
+          "command": "memory-inspector.apply-file",
+          "group": "debug",
+          "when": "memory-inspector.canWrite && resourceExtname === .hex"
+        }
+      ],
+      "editor/context": [
+        {
+          "command": "memory-inspector.apply-file",
+          "group": "debug",
+          "when": "memory-inspector.canWrite && resourceExtname === .hex"
         }
       ],
       "webview/context": [

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
       },
       {
         "command": "memory-inspector.store-file",
-        "title": "Store Memory as File",
+        "title": "Store Memory to File",
         "enablement": "memory-inspector.canRead",
         "category": "Memory"
       },
@@ -189,6 +189,16 @@
         {
           "command": "memory-inspector.show-advanced-display-options",
           "group": "display@4",
+          "when": "webviewId === memory-inspector.memory"
+        },
+        {
+          "command": "memory-inspector.store-file",
+          "group": "display@5",
+          "when": "webviewId === memory-inspector.memory"
+        },
+        {
+          "command": "memory-inspector.apply-file",
+          "group": "display@6",
           "when": "webviewId === memory-inspector.memory"
         }
       ]

--- a/src/common/debug-requests.ts
+++ b/src/common/debug-requests.ts
@@ -1,0 +1,39 @@
+/********************************************************************************
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+// inspired by https://github.com/eclipse-theia/theia/blob/master/packages/debug/src/browser/debug-session-connection.ts
+
+import type { DebugProtocol } from '@vscode/debugprotocol';
+import type { DebugSession } from 'vscode';
+
+export interface DebugRequestTypes {
+    'evaluate': [DebugProtocol.EvaluateArguments, DebugProtocol.EvaluateResponse['body']]
+    'readMemory': [DebugProtocol.ReadMemoryArguments, DebugProtocol.ReadMemoryResponse['body']]
+    'writeMemory': [DebugProtocol.WriteMemoryArguments, DebugProtocol.WriteMemoryResponse['body']]
+}
+
+export async function sendRequest<K extends keyof DebugRequestTypes>(session: DebugSession,
+    command: K, args: DebugRequestTypes[K][0]): Promise<DebugRequestTypes[K][1]> {
+    return session.customRequest(command, args);
+}
+
+export namespace EvaluateExpression {
+    export function sizeOf(expression: string): string {
+        return `sizeof(${expression})`;
+    }
+    export function addressOf(expression: string): string {
+        return `&(${expression})`;
+    }
+};

--- a/src/common/debug-requests.ts
+++ b/src/common/debug-requests.ts
@@ -29,11 +29,17 @@ export async function sendRequest<K extends keyof DebugRequestTypes>(session: De
     return session.customRequest(command, args);
 }
 
-export namespace EvaluateExpression {
-    export function sizeOf(expression: string): string {
-        return `sizeof(${expression})`;
-    }
-    export function addressOf(expression: string): string {
-        return `&(${expression})`;
-    }
-};
+export function isDebugVariable(variable: DebugProtocol.Variable | unknown): variable is DebugProtocol.Variable {
+    const assumed = variable ? variable as DebugProtocol.Variable : undefined;
+    return typeof assumed?.name === 'string' && typeof assumed?.value === 'string';
+}
+
+export function isDebugScope(scope: DebugProtocol.Scope | unknown): scope is DebugProtocol.Scope {
+    const assumed = scope ? scope as DebugProtocol.Scope : undefined;
+    return typeof assumed?.name === 'string' && typeof assumed?.variablesReference === 'number';
+}
+
+export function isDebugEvaluateArguments(args: DebugProtocol.EvaluateArguments | unknown): args is DebugProtocol.EvaluateArguments {
+    const assumed = args ? args as DebugProtocol.EvaluateArguments : undefined;
+    return typeof assumed?.expression === 'string';
+}

--- a/src/common/debug-requests.ts
+++ b/src/common/debug-requests.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2018 Red Hat, Inc. and others.
+ * Copyright (C) 2024 EclipseSource.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -32,8 +32,8 @@ export interface DebugEvents {
     'stopped': DebugProtocol.StoppedEvent
 }
 
-export type DebugRequest<COMMAND, ARGS> = Omit<DebugProtocol.Request, 'command' | 'arguments'> & { command: COMMAND, arguments: ARGS };
-export type DebugResponse<COMMAND, BODY> = Omit<DebugProtocol.Response, 'command' | 'body'> & { command: COMMAND, body: BODY };
+export type DebugRequest<C, A> = Omit<DebugProtocol.Request, 'command' | 'arguments'> & { command: C, arguments: A };
+export type DebugResponse<C, B> = Omit<DebugProtocol.Response, 'command' | 'body'> & { command: C, body: B };
 export type DebugEvent<T> = DebugProtocol.Event & { body: T };
 
 export async function sendRequest<K extends keyof DebugRequestTypes>(session: DebugSession,

--- a/src/common/intel-hex.ts
+++ b/src/common/intel-hex.ts
@@ -1,0 +1,43 @@
+/********************************************************************************
+ * Copyright (C) 2024 EclipseSource.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { URI, Utils } from 'vscode-uri';
+
+export namespace IntelHEX {
+    export namespace FileExtensions {
+        export const All = [
+            // General
+            'hex', 'mcs', 'int', 'ihex', 'ihe', 'ihx',
+            // Platform-specific
+            'h80', 'h86', 'a43', 'a90',
+            // Binary or Intel hex
+            'obj', 'obl', 'obh', 'rom', 'eep'
+        ];
+        export const Default = 'hex';
+
+        export function applyIfMissing(file: URI): URI {
+            const extWithDot = Utils.extname(file);
+            if (extWithDot.length === 0 || !IntelHEX.FileExtensions.All.includes(extWithDot.slice(1))) {
+                return URI.file(file.fsPath + '.' + IntelHEX.FileExtensions.Default);
+            }
+            return file;
+        };
+    };
+    export const DialogFilters = {
+        'Intel HEX Files': IntelHEX.FileExtensions.All,
+        'All Files': ['*']
+    };
+};

--- a/src/common/memory-range.ts
+++ b/src/common/memory-range.ts
@@ -91,7 +91,7 @@ export function getRadixMarker(radix: Radix): string {
     return radixPrefixMap[radix];
 }
 
-export function getAddressString(address: bigint, radix: Radix, paddedLength: number = 0): string {
+export function getAddressString(address: bigint | number, radix: Radix, paddedLength: number = 0): string {
     return address.toString(radix).padStart(paddedLength, '0');
 }
 
@@ -99,7 +99,7 @@ export function getAddressLength(padding: number, radix: Radix): number {
     return Math.ceil(padding / Math.log2(radix));
 }
 
-export function toHexStringWithRadixMarker(target: bigint, paddedLength: number = 0): string {
+export function toHexStringWithRadixMarker(target: bigint | number, paddedLength: number = 0): string {
     return `${getRadixMarker(Radix.Hexadecimal)}${getAddressString(target, Radix.Hexadecimal, paddedLength)}`;
 }
 

--- a/src/common/memory-range.ts
+++ b/src/common/memory-range.ts
@@ -27,6 +27,12 @@ export interface MemoryRange {
     endAddress?: string;
 }
 
+export interface WrittenMemory {
+    memoryReference: string;
+    offset?: number;
+    count?: number
+}
+
 /** Suitable for arithemetic */
 export interface BigIntMemoryRange {
     startAddress: bigint;
@@ -93,8 +99,8 @@ export function getAddressLength(padding: number, radix: Radix): number {
     return Math.ceil(padding / Math.log2(radix));
 }
 
-export function toHexStringWithRadixMarker(target: bigint): string {
-    return `${getRadixMarker(Radix.Hexadecimal)}${getAddressString(target, Radix.Hexadecimal)}`;
+export function toHexStringWithRadixMarker(target: bigint, paddedLength: number = 0): string {
+    return `${getRadixMarker(Radix.Hexadecimal)}${getAddressString(target, Radix.Hexadecimal, paddedLength)}`;
 }
 
 export interface VariableMetadata {

--- a/src/common/memory.ts
+++ b/src/common/memory.ts
@@ -1,0 +1,74 @@
+/********************************************************************************
+ * Copyright (C) 2024 EclipseSource.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import type { DebugProtocol } from '@vscode/debugprotocol';
+import { ReadMemoryResult } from './messaging';
+
+export interface Memory {
+    address: bigint;
+    bytes: Uint8Array;
+}
+
+export function createMemoryFromRead(result: ReadMemoryResult): Memory {
+    if (!result?.data) { throw new Error('No memory provided!'); }
+    const address = BigInt(result.address);
+    const bytes = stringToBytesMemory(result.data);
+    return { bytes, address };
+}
+
+export function stringToBytesMemory(data: string): Uint8Array {
+    return Uint8Array.from(Buffer.from(data, 'base64'));
+}
+
+export function bytesToStringMemory(data: Uint8Array): string {
+    return Buffer.from(data).toString('base64');
+}
+
+export function validateMemoryReference(reference: string): string | undefined {
+    const asNumber = Number(reference);
+    // we allow an address that is not a number, e.g., an expression, but if it is a number it must be >= 0
+    return !isNaN(asNumber) && asNumber < 0 ? 'Value needs to be >= 0' : undefined;
+}
+
+export function validateOffset(offset: string): string | undefined {
+    const asNumber = Number(offset);
+    return isNaN(asNumber) ? 'No number provided' : undefined;
+}
+
+export function validateCount(count: string): string | undefined {
+    const asNumber = Number(count);
+    if (isNaN(asNumber)) {
+        return 'No number provided';
+    } else if (asNumber <= 0) {
+        return 'Value needs to be > 0';
+    }
+}
+
+export interface MemoryVariable extends DebugProtocol.Variable {
+    memoryReference: string;
+}
+
+export const isMemoryVariable = (variable: unknown): variable is MemoryVariable => !!variable && !!(variable as MemoryVariable).memoryReference;
+
+export interface MemoryVariableNode {
+    variable: MemoryVariable;
+    sessionId: string;
+}
+
+export const isMemoryVariableNode = (node: unknown): node is MemoryVariableNode =>
+    !!node
+    && isMemoryVariable((node as MemoryVariableNode).variable)
+    && typeof (node as MemoryVariableNode).sessionId === 'string';

--- a/src/common/messaging.ts
+++ b/src/common/messaging.ts
@@ -21,6 +21,7 @@ import type { VariableRange, WrittenMemory } from './memory-range';
 import { DebugRequestTypes } from './debug-requests';
 import { URI } from 'vscode-uri';
 import { VariablesView } from '../plugin/external-views';
+import { WebviewContext } from './webview-context';
 
 // convenience types for easier readability and better semantics
 export type MemoryOptions = Partial<DebugProtocol.ReadMemoryArguments>;
@@ -31,7 +32,7 @@ export type ReadMemoryResult = DebugRequestTypes['readMemory'][1];
 export type WriteMemoryArguments = DebugRequestTypes['writeMemory'][0] & { count?: number };
 export type WriteMemoryResult = DebugRequestTypes['writeMemory'][1];
 
-export type StoreMemoryArguments = MemoryOptions & { proposedOutputName?: string } | VariablesView.IVariablesContext;
+export type StoreMemoryArguments = MemoryOptions & { proposedOutputName?: string } | VariablesView.IVariablesContext | WebviewContext;
 export type StoreMemoryResult = void;
 
 export type ApplyMemoryArguments = URI | undefined;

--- a/src/common/messaging.ts
+++ b/src/common/messaging.ts
@@ -19,8 +19,8 @@ import type { NotificationType, RequestType } from 'vscode-messenger-common';
 import { MemoryViewSettings } from '../webview/utils/view-types';
 import type { VariableRange, WrittenMemory } from './memory-range';
 import { DebugRequestTypes } from './debug-requests';
-import { MemoryVariableNode } from './memory';
 import { URI } from 'vscode-uri';
+import { VariablesView } from '../plugin/external-views';
 
 // convenience types for easier readability and better semantics
 export type MemoryOptions = Partial<DebugProtocol.ReadMemoryArguments>;
@@ -31,7 +31,7 @@ export type ReadMemoryResult = DebugRequestTypes['readMemory'][1];
 export type WriteMemoryArguments = DebugRequestTypes['writeMemory'][0] & { count?: number };
 export type WriteMemoryResult = DebugRequestTypes['writeMemory'][1];
 
-export type StoreMemoryArguments = MemoryOptions | MemoryVariableNode;
+export type StoreMemoryArguments = MemoryOptions & { proposedOutputName?: string } | VariablesView.IVariablesContext;
 export type StoreMemoryResult = void;
 
 export type ApplyMemoryArguments = URI | undefined;

--- a/src/common/messaging.ts
+++ b/src/common/messaging.ts
@@ -37,12 +37,19 @@ export type StoreMemoryResult = void;
 export type ApplyMemoryArguments = URI | undefined;
 export type ApplyMemoryResult = MemoryOptions;
 
+export interface SessionContext {
+    sessionId?: string;
+    canRead: boolean;
+    canWrite: boolean;
+}
+
 // Notifications
 export const readyType: NotificationType<void> = { method: 'ready' };
 export const setMemoryViewSettingsType: NotificationType<Partial<MemoryViewSettings>> = { method: 'setMemoryViewSettings' };
 export const resetMemoryViewSettingsType: NotificationType<void> = { method: 'resetMemoryViewSettings' };
 export const setTitleType: NotificationType<string> = { method: 'setTitle' };
 export const memoryWrittenType: NotificationType<WrittenMemory> = { method: 'memoryWritten' };
+export const sessionContextChangedType: NotificationType<SessionContext> = { method: 'sessionContextChanged' };
 
 // Requests
 export const setOptionsType: RequestType<MemoryOptions, void> = { method: 'setOptions' };

--- a/src/common/messaging.ts
+++ b/src/common/messaging.ts
@@ -17,20 +17,41 @@
 import type { DebugProtocol } from '@vscode/debugprotocol';
 import type { NotificationType, RequestType } from 'vscode-messenger-common';
 import { MemoryViewSettings } from '../webview/utils/view-types';
-import type { VariableRange } from './memory-range';
+import type { VariableRange, WrittenMemory } from './memory-range';
+import { DebugRequestTypes } from './debug-requests';
+import { MemoryVariableNode } from './memory';
+import { URI } from 'vscode-uri';
 
-export type MemoryReadResult = DebugProtocol.ReadMemoryResponse['body'];
-export type MemoryWriteResult = DebugProtocol.WriteMemoryResponse['body'];
+// convenience types for easier readability and better semantics
+export type MemoryOptions = Partial<DebugProtocol.ReadMemoryArguments>;
 
+export type ReadMemoryArguments = DebugRequestTypes['readMemory'][0];
+export type ReadMemoryResult = DebugRequestTypes['readMemory'][1];
+
+export type WriteMemoryArguments = DebugRequestTypes['writeMemory'][0] & { count?: number };
+export type WriteMemoryResult = DebugRequestTypes['writeMemory'][1];
+
+export type StoreMemoryArguments = MemoryOptions | MemoryVariableNode;
+export type StoreMemoryResult = void;
+
+export type ApplyMemoryArguments = URI | undefined;
+export type ApplyMemoryResult = MemoryOptions;
+
+// Notifications
 export const readyType: NotificationType<void> = { method: 'ready' };
-export const logMessageType: RequestType<string, void> = { method: 'logMessage' };
 export const setMemoryViewSettingsType: NotificationType<Partial<MemoryViewSettings>> = { method: 'setMemoryViewSettings' };
 export const resetMemoryViewSettingsType: NotificationType<void> = { method: 'resetMemoryViewSettings' };
 export const setTitleType: NotificationType<string> = { method: 'setTitle' };
-export const setOptionsType: RequestType<Partial<DebugProtocol.ReadMemoryArguments | undefined>, void> = { method: 'setOptions' };
-export const readMemoryType: RequestType<DebugProtocol.ReadMemoryArguments, MemoryReadResult> = { method: 'readMemory' };
-export const writeMemoryType: RequestType<DebugProtocol.WriteMemoryArguments, MemoryWriteResult> = { method: 'writeMemory' };
-export const getVariables: RequestType<DebugProtocol.ReadMemoryArguments, VariableRange[]> = { method: 'getVariables' };
+export const memoryWrittenType: NotificationType<WrittenMemory> = { method: 'memoryWritten' };
+
+// Requests
+export const setOptionsType: RequestType<MemoryOptions, void> = { method: 'setOptions' };
+export const logMessageType: RequestType<string, void> = { method: 'logMessage' };
+export const readMemoryType: RequestType<ReadMemoryArguments, ReadMemoryResult> = { method: 'readMemory' };
+export const writeMemoryType: RequestType<WriteMemoryArguments, WriteMemoryResult> = { method: 'writeMemory' };
+export const getVariablesType: RequestType<ReadMemoryArguments, VariableRange[]> = { method: 'getVariables' };
+export const storeMemoryType: RequestType<StoreMemoryArguments, void> = { method: 'storeMemory' };
+export const applyMemoryType: RequestType<ApplyMemoryArguments, ApplyMemoryResult> = { method: 'applyMemory' };
 
 export const showAdvancedOptionsType: NotificationType<void> = { method: 'showAdvancedOptions' };
 export const getWebviewSelectionType: RequestType<void, WebviewSelection> = { method: 'getWebviewSelection' };

--- a/src/common/messaging.ts
+++ b/src/common/messaging.ts
@@ -29,7 +29,7 @@ export type MemoryOptions = Partial<DebugProtocol.ReadMemoryArguments>;
 export type ReadMemoryArguments = DebugRequestTypes['readMemory'][0];
 export type ReadMemoryResult = DebugRequestTypes['readMemory'][1];
 
-export type WriteMemoryArguments = DebugRequestTypes['writeMemory'][0] & { count?: number };
+export type WriteMemoryArguments = DebugRequestTypes['writeMemory'][0];
 export type WriteMemoryResult = DebugRequestTypes['writeMemory'][1];
 
 export type StoreMemoryArguments = MemoryOptions & { proposedOutputName?: string } | VariablesView.IVariablesContext | WebviewContext;

--- a/src/common/typescript.ts
+++ b/src/common/typescript.ts
@@ -19,3 +19,8 @@ export function tryToNumber(value?: string | number): number | undefined {
     if (value === '' || isNaN(asNumber)) { return undefined; }
     return asNumber;
 }
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function stringifyWithBigInts(object: any, space?: string | number): any {
+    return JSON.stringify(object, (_key, value) => typeof value === 'bigint' ? value.toString() : value, space);
+}

--- a/src/common/webview-context.ts
+++ b/src/common/webview-context.ts
@@ -16,6 +16,7 @@
 
 import { WebviewIdMessageParticipant } from 'vscode-messenger-common';
 import { VariableMetadata } from './memory-range';
+import { ReadMemoryArguments } from './messaging';
 
 export interface WebviewContext {
     messageParticipant: WebviewIdMessageParticipant,
@@ -23,6 +24,7 @@ export interface WebviewContext {
     showAsciiColumn: boolean
     showVariablesColumn: boolean,
     showRadixPrefix: boolean,
+    activeReadArguments: Required<ReadMemoryArguments>
 }
 
 export interface WebviewCellContext extends WebviewContext {
@@ -47,4 +49,12 @@ export function getVisibleColumns(context: WebviewContext): string[] {
         columns.push('variables');
     }
     return columns;
+}
+
+export function isWebviewContext(args: WebviewContext | unknown): args is WebviewContext {
+    const assumed = args ? args as WebviewContext : undefined;
+    return typeof assumed?.messageParticipant?.type === 'string' && assumed.messageParticipant.type === 'webview' && typeof assumed.messageParticipant.webviewId === 'string'
+        && typeof assumed.webviewSection === 'string' && typeof assumed.showAsciiColumn === 'boolean' && typeof assumed.showVariablesColumn === 'boolean'
+        && typeof assumed.showRadixPrefix === 'boolean' && typeof assumed.activeReadArguments?.count === 'number' && typeof assumed.activeReadArguments?.offset === 'number'
+        && typeof assumed.activeReadArguments?.memoryReference === 'string';
 }

--- a/src/entry-points/browser/extension.ts
+++ b/src/entry-points/browser/extension.ts
@@ -19,16 +19,19 @@ import { AdapterRegistry } from '../../plugin/adapter-registry/adapter-registry'
 import { MemoryProvider } from '../../plugin/memory-provider';
 import { MemoryWebview } from '../../plugin/memory-webview-main';
 import { CAdapter } from '../../plugin/adapter-registry/c-adapter';
+import { MemoryStorage } from '../../plugin/memory-storage';
 
 export const activate = async (context: vscode.ExtensionContext): Promise<AdapterRegistry> => {
     const registry = new AdapterRegistry();
     const memoryProvider = new MemoryProvider(registry);
     const memoryView = new MemoryWebview(context.extensionUri, memoryProvider);
+    const memoryStorage = new MemoryStorage(memoryProvider);
     const cAdapter = new CAdapter(registry);
 
     registry.activate(context);
     memoryProvider.activate(context);
     memoryView.activate(context);
+    memoryStorage.activate(context);
     cAdapter.activate(context);
 
     return registry;

--- a/src/entry-points/desktop/extension.ts
+++ b/src/entry-points/desktop/extension.ts
@@ -19,16 +19,19 @@ import { AdapterRegistry } from '../../plugin/adapter-registry/adapter-registry'
 import { MemoryProvider } from '../../plugin/memory-provider';
 import { MemoryWebview } from '../../plugin/memory-webview-main';
 import { CAdapter } from '../../plugin/adapter-registry/c-adapter';
+import { MemoryStorage } from '../../plugin/memory-storage';
 
 export const activate = async (context: vscode.ExtensionContext): Promise<AdapterRegistry> => {
     const registry = new AdapterRegistry();
     const memoryProvider = new MemoryProvider(registry);
     const memoryView = new MemoryWebview(context.extensionUri, memoryProvider);
+    const memoryStorage = new MemoryStorage(memoryProvider);
     const cAdapter = new CAdapter(registry);
 
     memoryProvider.activate(context);
     registry.activate(context);
     memoryView.activate(context);
+    memoryStorage.activate(context);
     cAdapter.activate(context);
 
     return registry;

--- a/src/plugin/adapter-registry/adapter-capabilities.ts
+++ b/src/plugin/adapter-registry/adapter-capabilities.ts
@@ -112,7 +112,7 @@ export class AdapterVariableTracker implements vscode.DebugAdapterTracker {
         throw new Error('To be implemented by derived classes!');
     }
 
-    /** Resolves the address of a given variable in bytes withthe current context. */
+    /** Resolves the address of a given variable in bytes within the current context. */
     getAddressOfVariable?(variableName: string, session: vscode.DebugSession): Promise<string | undefined>;
 
     /** Resolves the size of a given variable in bytes within the current context. */

--- a/src/plugin/adapter-registry/adapter-capabilities.ts
+++ b/src/plugin/adapter-registry/adapter-capabilities.ts
@@ -38,6 +38,10 @@ export type VariablesTree = Record<number, WithChildren<DebugProtocol.Scope | De
 export const hexAddress = /0x[0-9a-f]+/i;
 export const notADigit = /[^0-9]/;
 
+export function findHexAddress(text?: string): string | undefined {
+    return text ? hexAddress.exec(text)?.[0] : undefined;
+}
+
 /** This class implements some of the basic elements of tracking adapter sessions in order to maintain a list of variables. */
 export class AdapterVariableTracker implements vscode.DebugAdapterTracker {
     protected currentFrame?: number;

--- a/src/plugin/adapter-registry/adapter-capabilities.ts
+++ b/src/plugin/adapter-registry/adapter-capabilities.ts
@@ -36,10 +36,20 @@ export interface AdapterCapabilities {
 export type WithChildren<Original> = Original & { children?: Array<WithChildren<DebugProtocol.Variable>> };
 export type VariablesTree = Record<number, WithChildren<DebugProtocol.Scope | DebugProtocol.Variable>>;
 export const hexAddress = /0x[0-9a-f]+/i;
+export const decimalAddress = /[0-9]+/i;
 export const notADigit = /[^0-9]/;
 
-export function findHexAddress(text?: string): string | undefined {
+export function extractHexAddress(text?: string): string | undefined {
     return text ? hexAddress.exec(text)?.[0] : undefined;
+}
+
+export function extractDecimalAddress(text?: string): string | undefined {
+    return text ? decimalAddress.exec(text)?.[0] : undefined;
+}
+
+export function extractAddress(text?: string): string | undefined {
+    // search for hex address first as a hex adress (0x12345678) also matches an integer address (12345678)
+    return text ? extractHexAddress(text) ?? extractDecimalAddress(text) : undefined;
 }
 
 /** This class implements some of the basic elements of tracking adapter sessions in order to maintain a list of variables. */

--- a/src/plugin/adapter-registry/c-tracker.ts
+++ b/src/plugin/adapter-registry/c-tracker.ts
@@ -42,13 +42,14 @@ export class CTracker extends AdapterVariableTracker {
             return undefined;
         }
         try {
-            const variableAddress = await this.getAddressOfVariable(variable.name, session);
+            const [variableAddress, variableSize] = await Promise.all([
+                variable.memoryReference && hexAddress.test(variable.memoryReference) ? variable.memoryReference : this.getAddressOfVariable(variable.name, session),
+                this.getSizeOfVariable(variable.name, session)
+            ]);
             if (!variableAddress) { return undefined; }
-            const variableSize = await this.getSizeOfVariable(variable.name, session);
-            if (!variableSize) { return undefined; }
 
             const startAddress = BigInt(variableAddress);
-            const endAddress = BigInt(variableAddress) + variableSize;
+            const endAddress = variableSize !== undefined ? startAddress + variableSize : undefined;
             this.logger.debug('Resolved', variable.name, { start: variableAddress, size: variableSize });
             return {
                 name: variable.name,

--- a/src/plugin/external-views.ts
+++ b/src/plugin/external-views.ts
@@ -1,0 +1,32 @@
+/********************************************************************************
+ * Copyright (C) 2024 EclipseSource.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { DebugProtocol } from '@vscode/debugprotocol';
+import { isDebugVariable, isDebugScope, isDebugEvaluateArguments } from '../common/debug-requests';
+
+export namespace VariablesView {
+    // from https://github.com/microsoft/vscode/blob/main/src/vs/workbench/contrib/debug/browser/variablesView.ts
+    export interface IVariablesContext {
+        sessionId: string | undefined;
+        container: DebugProtocol.Variable | DebugProtocol.Scope | DebugProtocol.EvaluateArguments;
+        variable: DebugProtocol.Variable;
+    }
+}
+
+export function isVariablesContext(context: VariablesView.IVariablesContext | unknown): context is VariablesView.IVariablesContext {
+    const assumed = context ? context as VariablesView.IVariablesContext : undefined;
+    return isDebugVariable(assumed?.variable) && (isDebugVariable(assumed?.container) || isDebugScope(assumed?.container) || isDebugEvaluateArguments(assumed?.container));
+}

--- a/src/plugin/logger.ts
+++ b/src/plugin/logger.ts
@@ -16,6 +16,7 @@
 
 import * as vscode from 'vscode';
 import * as manifest from './manifest';
+import { stringifyWithBigInts } from '../common/typescript';
 
 export enum Verbosity {
     off = 0,
@@ -50,7 +51,7 @@ export abstract class Logger {
             return;
         }
 
-        const result = messages.map(message => typeof message === 'string' ? message : JSON.stringify(message, undefined, '\t')).join(' ');
+        const result = messages.map(message => typeof message === 'string' ? message : stringifyWithBigInts(message, '\t')).join(' ');
 
         this.logMessage(result);
     }

--- a/src/plugin/memory-provider.ts
+++ b/src/plugin/memory-provider.ts
@@ -132,14 +132,22 @@ export class MemoryProvider {
         });
     }
 
-    public async evaluate(args: DebugProtocol.EvaluateArguments): Promise<DebugProtocol.EvaluateResponse['body']> {
-        return sendRequest(this.assertActiveSession('evaluate'), 'evaluate', args);
-    }
-
     public async getVariables(variableArguments: DebugProtocol.ReadMemoryArguments): Promise<VariableRange[]> {
         const session = this.assertActiveSession('get variables');
         const handler = this.adapterRegistry?.getHandlerForSession(session.type);
         if (handler?.getResidents) { return handler.getResidents(session, variableArguments); }
         return handler?.getVariables?.(session) ?? [];
+    }
+
+    public async getAddressOfVariable(variableName: string): Promise<string | undefined> {
+        const session = this.assertActiveSession('get address of variable');
+        const handler = this.adapterRegistry?.getHandlerForSession(session.type);
+        return handler?.getAddressOfVariable?.(session, variableName);
+    }
+
+    public async getSizeOfVariable(variableName: string): Promise<bigint | undefined> {
+        const session = this.assertActiveSession('get address of variable');
+        const handler = this.adapterRegistry?.getHandlerForSession(session.type);
+        return handler?.getSizeOfVariable?.(session, variableName);
     }
 }

--- a/src/plugin/memory-storage.ts
+++ b/src/plugin/memory-storage.ts
@@ -169,7 +169,7 @@ export class MemoryStorage {
                 memoryReference = toHexStringWithRadixMarker(address);
                 count = memory.length;
                 const data = bytesToStringMemory(memory);
-                await this.memoryProvider.writeMemory({ memoryReference, data, count });
+                await this.memoryProvider.writeMemory({ memoryReference, data });
             }
             await vscode.window.showInformationMessage(`Memory from '${vscode.workspace.asRelativePath(options.uri)}' applied.`);
             return { memoryReference, count, offset: 0 };

--- a/src/plugin/memory-storage.ts
+++ b/src/plugin/memory-storage.ts
@@ -1,0 +1,194 @@
+/********************************************************************************
+ * Copyright (C) 2024 EclipseSource.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import MemoryMap from 'nrf-intel-hex';
+import * as vscode from 'vscode';
+import { URI, Utils } from 'vscode-uri';
+import { IntelHEX } from '../common/intel-hex';
+import {
+    bytesToStringMemory, createMemoryFromRead,
+    isMemoryVariableNode, validateCount, validateMemoryReference, validateOffset
+} from '../common/memory';
+import { toHexStringWithRadixMarker } from '../common/memory-range';
+import * as manifest from './manifest';
+import { MemoryProvider } from './memory-provider';
+import { EvaluateExpression } from '../common/debug-requests';
+import { ApplyMemoryArguments, ApplyMemoryResult, MemoryOptions, StoreMemoryArguments } from '../common/messaging';
+
+export const StoreCommandType = `${manifest.PACKAGE_NAME}.store-file`;
+export const ApplyCommandType = `${manifest.PACKAGE_NAME}.apply-file`;
+
+const VALID_FILE_NAME_CHARS = /[^a-zA-Z0-9 _-]/g;
+
+type StoreMemoryOptions = Required<MemoryOptions> & {
+    outputFile: vscode.Uri;
+};
+
+const DEFAULT_STORE_OPTIONS: Omit<StoreMemoryOptions, 'outputFile'> = {
+    memoryReference: toHexStringWithRadixMarker(0n, 8),
+    offset: 0,
+    count: 256
+};
+
+interface ApplyMemoryOptions {
+    uri: vscode.Uri;
+}
+
+export class MemoryStorage {
+    constructor(protected memoryProvider: MemoryProvider) {
+    }
+
+    public activate(context: vscode.ExtensionContext): void {
+        context.subscriptions.push(
+            vscode.commands.registerCommand(StoreCommandType, args => this.storeMemory(args)),
+            vscode.commands.registerCommand(ApplyCommandType, args => this.applyMemory(args))
+        );
+    }
+
+    public async storeMemory(args?: StoreMemoryArguments): Promise<void> {
+        const providedDefaultOptions = await this.storeArgsToOptions(args);
+        const options = await this.getStoreMemoryOptions(providedDefaultOptions);
+        if (!options) {
+            // user aborted process
+            return;
+        }
+
+        const { outputFile, ...readArgs } = options;
+        try {
+            const memoryResponse = await this.memoryProvider.readMemory(readArgs);
+            const memory = createMemoryFromRead(memoryResponse);
+            const memoryMap = new MemoryMap({ [Number(memory.address)]: memory.bytes });
+            await vscode.workspace.fs.writeFile(outputFile, new TextEncoder().encode(memoryMap.asHexString()));
+        } catch (error) {
+            if (error instanceof Error) {
+                vscode.window.showErrorMessage(`Could not write memory to '${vscode.workspace.asRelativePath(outputFile)}': ${error.message}`);
+            } else {
+                vscode.window.showErrorMessage(`Could not write memory to '${vscode.workspace.asRelativePath(outputFile)}': ${error}`);
+            }
+            return;
+        }
+
+        const option = await vscode.window.showInformationMessage(`File '${vscode.workspace.asRelativePath(outputFile)}' saved.`, 'Open File');
+        if (option === 'Open File') {
+            await vscode.window.showTextDocument(outputFile);
+        }
+    }
+
+    protected async storeArgsToOptions(args?: StoreMemoryArguments): Promise<Partial<StoreMemoryOptions>> {
+        if (!args) {
+            return {};
+        }
+        if (isMemoryVariableNode(args)) {
+            try {
+                const variableName = args.variable.evaluateName ?? args.variable.name;
+                const { result } = await this.memoryProvider.evaluate({ expression: EvaluateExpression.sizeOf(variableName), context: 'watch' });
+                const count = validateCount(result) === undefined ? Number(result) : undefined;
+                return { count, memoryReference: EvaluateExpression.addressOf(variableName), offset: 0 };
+            } catch (error) {
+                // ignore, we are just using them as default values
+                return { memoryReference: args.variable.memoryReference, offset: 0 };
+            }
+        }
+        return args;
+    }
+
+    protected async getStoreMemoryOptions(providedDefault?: Partial<StoreMemoryOptions>): Promise<StoreMemoryOptions | undefined> {
+        const memoryReference = await vscode.window.showInputBox({
+            title: 'Store Memory as File (1/3)',
+            prompt: 'Start Memory Address',
+            placeHolder: 'Hex address or expression',
+            value: providedDefault?.memoryReference ?? DEFAULT_STORE_OPTIONS.memoryReference,
+            validateInput: validateMemoryReference
+        });
+        if (!memoryReference) {
+            return;
+        }
+        const offset = await vscode.window.showInputBox({
+            title: 'Store Memory as File (2/3)',
+            prompt: 'Memory Address Offset',
+            placeHolder: 'Positive or negative offset in bytes',
+            value: providedDefault?.offset?.toString() ?? DEFAULT_STORE_OPTIONS.offset.toString(),
+            validateInput: validateOffset
+        });
+        if (!offset) {
+            return;
+        }
+        const count = await vscode.window.showInputBox({
+            title: 'Store Memory as File (3/3)',
+            prompt: 'Length',
+            placeHolder: 'Number of bytes to read',
+            value: providedDefault?.count?.toString() ?? DEFAULT_STORE_OPTIONS.count.toString(),
+            validateInput: validateCount
+        });
+        if (!count) {
+            return;
+        }
+        const workspaceUri = vscode.workspace.workspaceFolders?.[0]?.uri;
+        const defaultUri = workspaceUri ? Utils.joinPath(workspaceUri, memoryReference.replace(VALID_FILE_NAME_CHARS, '') + '_' + count) : workspaceUri;
+        const saveFile = await vscode.window.showSaveDialog({ title: 'Store Memory', defaultUri, filters: IntelHEX.DialogFilters });
+        if (!saveFile) {
+            return;
+        }
+        const outputFile = IntelHEX.FileExtensions.applyIfMissing(saveFile);
+        return { memoryReference, offset: Number(offset), count: Number(count), outputFile };
+    }
+
+    public async applyMemory(args?: ApplyMemoryArguments): Promise<ApplyMemoryResult> {
+        const providedDefaultOptions = await this.applyArgsToOptions(args);
+        const options = await this.getApplyMemoryOptions(providedDefaultOptions);
+        if (!options) {
+            // user aborted process
+            return {};
+        }
+        try {
+            const byteContent = await vscode.workspace.fs.readFile(options.uri);
+            const memoryMap = MemoryMap.fromHex(new TextDecoder().decode(byteContent));
+            let memoryReference: string | undefined;
+            let count: number | undefined;
+            for (const [address, memory] of memoryMap) {
+                memoryReference = toHexStringWithRadixMarker(BigInt(address));
+                count = memory.length;
+                const data = bytesToStringMemory(memory);
+                await this.memoryProvider.writeMemory({ memoryReference, data, count });
+            }
+            await vscode.window.showInformationMessage(`Memory from '${vscode.workspace.asRelativePath(options.uri)}' applied.`);
+            return { memoryReference, count, offset: 0 };
+        } catch (error) {
+            if (error instanceof Error) {
+                vscode.window.showErrorMessage(`Could not apply memory from '${vscode.workspace.asRelativePath(options.uri)}': ${error.message}`);
+            } else {
+                vscode.window.showErrorMessage(`Could not apply memory from '${vscode.workspace.asRelativePath(options.uri)}': ${error}`);
+            }
+            return {};
+        }
+    }
+
+    protected async applyArgsToOptions(args?: ApplyMemoryArguments): Promise<Partial<ApplyMemoryOptions>> {
+        return URI.isUri(args) ? { uri: args } : {};
+    }
+
+    protected async getApplyMemoryOptions(providedDefault?: Partial<ApplyMemoryOptions>): Promise<ApplyMemoryOptions | undefined> {
+        if (providedDefault?.uri) {
+            // if we are already given a URI, let's not bother the user and simply use it
+            return { uri: providedDefault.uri };
+        }
+        const selectedUris = await vscode.window.showOpenDialog({ title: 'Apply Memory', filters: IntelHEX.DialogFilters });
+        if (selectedUris && selectedUris?.length > 0) {
+            return { uri: selectedUris[0] };
+        }
+        return undefined;
+    }
+}

--- a/src/plugin/memory-webview-main.ts
+++ b/src/plugin/memory-webview-main.ts
@@ -206,7 +206,7 @@ export class MemoryWebview implements vscode.CustomReadonlyEditorProvider {
         const disposables = [
             this.messenger.onNotification(readyType, () => {
                 this.setInitialSettings(participant, panel.title);
-                this.setSessionContext(participant, this.memoryProvider.sessionContext);
+                this.setSessionContext(participant, this.memoryProvider.createContext());
                 this.refresh(participant, options);
             }, { sender: participant }),
             this.messenger.onRequest(setOptionsType, o => {
@@ -316,7 +316,7 @@ export class MemoryWebview implements vscode.CustomReadonlyEditorProvider {
     protected async storeMemory(storeArguments: StoreMemoryArguments): Promise<void> {
         // Even if we disable the command in VS Code through enablement or when condition, programmatic execution is still possible.
         // However, we want to fail early in case the user tries to execute a disabled command
-        if (!this.memoryProvider.sessionContext.canRead) {
+        if (!this.memoryProvider.createContext().canRead) {
             throw new Error('Cannot read memory, no valid debug session.');
         }
         return vscode.commands.executeCommand(StoreCommandType, storeArguments);
@@ -325,7 +325,7 @@ export class MemoryWebview implements vscode.CustomReadonlyEditorProvider {
     protected async applyMemory(): Promise<MemoryOptions> {
         // Even if we disable the command in VS Code through enablement or when condition, programmatic execution is still possible.
         // However, we want to fail early in case the user tries to execute a disabled command
-        if (!this.memoryProvider.sessionContext.canWrite) {
+        if (!this.memoryProvider.createContext().canWrite) {
             throw new Error('Cannot write memory, no valid debug session.');
         }
         return vscode.commands.executeCommand(ApplyCommandType);

--- a/src/webview/columns/address-column.tsx
+++ b/src/webview/columns/address-column.tsx
@@ -17,7 +17,7 @@
 import React, { ReactNode } from 'react';
 import { BigIntMemoryRange, getAddressString, getRadixMarker } from '../../common/memory-range';
 import { ColumnContribution, ColumnFittingType, TableRenderOptions } from './column-contribution-service';
-import { Memory } from '../utils/view-types';
+import { Memory } from '../../common/memory';
 
 export class AddressColumn implements ColumnContribution {
     static ID = 'address';

--- a/src/webview/columns/ascii-column.ts
+++ b/src/webview/columns/ascii-column.ts
@@ -17,7 +17,7 @@
 import { ReactNode } from 'react';
 import { BigIntMemoryRange, toOffset } from '../../common/memory-range';
 import { ColumnContribution, TableRenderOptions } from './column-contribution-service';
-import { Memory } from '../utils/view-types';
+import { Memory } from '../../common/memory';
 
 function isPrintableAsAscii(input: number): boolean {
     return input >= 32 && input < (128 - 1);

--- a/src/webview/columns/column-contribution-service.ts
+++ b/src/webview/columns/column-contribution-service.ts
@@ -14,10 +14,11 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { DebugProtocol } from '@vscode/debugprotocol';
 import type * as React from 'react';
 import { BigIntMemoryRange } from '../../common/memory-range';
-import type { Disposable, Memory, MemoryState, SerializedTableRenderOptions, UpdateExecutor } from '../utils/view-types';
+import type { Disposable, MemoryState, SerializedTableRenderOptions, UpdateExecutor } from '../utils/view-types';
+import { Memory } from '../../common/memory';
+import { ReadMemoryArguments } from '../../common/messaging';
 
 export type ColumnFittingType = 'content-width';
 
@@ -31,7 +32,7 @@ export interface ColumnContribution {
     priority?: number;
     render(range: BigIntMemoryRange, memory: Memory, options: TableRenderOptions): React.ReactNode
     /** Called when fetching new memory or when activating the column. */
-    fetchData?(currentViewParameters: DebugProtocol.ReadMemoryArguments): Promise<void>;
+    fetchData?(currentViewParameters: ReadMemoryArguments): Promise<void>;
     /** Called when the user reveals the column */
     activate?(memory: MemoryState): Promise<void>;
     /** Called when the user hides the column */

--- a/src/webview/columns/data-column.tsx
+++ b/src/webview/columns/data-column.tsx
@@ -16,11 +16,12 @@
 
 import * as React from 'react';
 import { BigIntMemoryRange, Endianness, toOffset } from '../../common/memory-range';
-import { FullNodeAttributes, Memory } from '../utils/view-types';
+import { FullNodeAttributes } from '../utils/view-types';
 import { ColumnContribution, TableRenderOptions } from './column-contribution-service';
 import { decorationService } from '../decorations/decoration-service';
 import type { MemorySizeOptions } from '../components/memory-table';
 import { elementInnerWidth, characterWidthInContainer } from '../utils/window';
+import { Memory } from '../../common/memory';
 
 export class DataColumn implements ColumnContribution {
     static CLASS_NAME = 'column-data';

--- a/src/webview/components/memory-table.tsx
+++ b/src/webview/components/memory-table.tsx
@@ -442,7 +442,7 @@ export class MemoryTable extends React.PureComponent<MemoryTableProps, MemoryTab
         }
 
         /*
-         * Before opening a context menu for a table cell target we dynamically add the `value` property to the <vscode-data-context.
+         * Before opening a context menu for a table cell target we dynamically add the value property to the vscode-data-context.
          * Using this dynamic approach ensures the the cell value is also set correctly when the menu was opened on empty cell space.
          */
         const value = cell.textContent;

--- a/src/webview/components/memory-table.tsx
+++ b/src/webview/components/memory-table.tsx
@@ -22,13 +22,15 @@ import { ProgressSpinner } from 'primereact/progressspinner';
 import { Tooltip } from 'primereact/tooltip';
 import React from 'react';
 import { TableRenderOptions } from '../columns/column-contribution-service';
-import { Decoration, Memory, MemoryDisplayConfiguration, ScrollingBehavior, isTrigger } from '../utils/view-types';
+import { Decoration, MemoryDisplayConfiguration, ScrollingBehavior, isTrigger } from '../utils/view-types';
 import isDeepEqual from 'fast-deep-equal';
 import { classNames } from 'primereact/utils';
 import { tryToNumber } from '../../common/typescript';
 import { DataColumn } from '../columns/data-column';
 import { createColumnVscodeContext, createSectionVscodeContext } from '../utils/vscode-contexts';
 import { WebviewSelection } from '../../common/messaging';
+import { ReadMemoryArguments } from '../../common/messaging';
+import { Memory } from '../../common/memory';
 import { debounce } from 'lodash';
 import type { HoverService } from '../hovers/hover-service';
 import { TooltipEvent } from 'primereact/tooltip/tooltipoptions';
@@ -37,7 +39,7 @@ export interface MoreMemorySelectProps {
     activeReadArguments: Required<DebugProtocol.ReadMemoryArguments>;
     options: number[];
     direction: 'above' | 'below';
-    fetchMemory(partialOptions?: Partial<DebugProtocol.ReadMemoryArguments>): Promise<void>;
+    fetchMemory(partialOptions?: Partial<ReadMemoryArguments>): Promise<void>;
     disabled: boolean
 }
 
@@ -134,7 +136,7 @@ interface MemoryTableProps extends TableRenderOptions, MemoryDisplayConfiguratio
     decorations: Decoration[];
     effectiveAddressLength: number;
     hoverService: HoverService;
-    fetchMemory(partialOptions?: Partial<DebugProtocol.ReadMemoryArguments>): Promise<void>;
+    fetchMemory(partialOptions?: Partial<ReadMemoryArguments>): Promise<void>;
     isMemoryFetching: boolean;
     isFrozen: boolean;
 }

--- a/src/webview/components/memory-table.tsx
+++ b/src/webview/components/memory-table.tsx
@@ -14,7 +14,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { DebugProtocol } from '@vscode/debugprotocol';
 import memoize from 'memoize-one';
 import { Column } from 'primereact/column';
 import { DataTable, DataTableCellSelection, DataTableProps, DataTableSelectionCellChangeEvent } from 'primereact/datatable';
@@ -29,17 +28,17 @@ import { tryToNumber } from '../../common/typescript';
 import { DataColumn } from '../columns/data-column';
 import { createColumnVscodeContext, createSectionVscodeContext } from '../utils/vscode-contexts';
 import { WebviewSelection } from '../../common/messaging';
-import { ReadMemoryArguments } from '../../common/messaging';
+import { MemoryOptions, ReadMemoryArguments } from '../../common/messaging';
 import { Memory } from '../../common/memory';
 import { debounce } from 'lodash';
 import type { HoverService } from '../hovers/hover-service';
 import { TooltipEvent } from 'primereact/tooltip/tooltipoptions';
 
 export interface MoreMemorySelectProps {
-    activeReadArguments: Required<DebugProtocol.ReadMemoryArguments>;
+    activeReadArguments: Required<ReadMemoryArguments>;
     options: number[];
     direction: 'above' | 'below';
-    fetchMemory(partialOptions?: Partial<ReadMemoryArguments>): Promise<void>;
+    fetchMemory(partialOptions?: MemoryOptions): Promise<void>;
     disabled: boolean
 }
 
@@ -130,8 +129,8 @@ export const MoreMemorySelect: React.FC<MoreMemoryAboveSelectProps | MoreMemoryB
 };
 
 interface MemoryTableProps extends TableRenderOptions, MemoryDisplayConfiguration {
-    configuredReadArguments: Required<DebugProtocol.ReadMemoryArguments>;
-    activeReadArguments: Required<DebugProtocol.ReadMemoryArguments>;
+    configuredReadArguments: Required<ReadMemoryArguments>;
+    activeReadArguments: Required<ReadMemoryArguments>;
     memory?: Memory;
     decorations: Decoration[];
     effectiveAddressLength: number;

--- a/src/webview/components/memory-widget.tsx
+++ b/src/webview/components/memory-widget.tsx
@@ -14,7 +14,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { DebugProtocol } from '@vscode/debugprotocol';
 import React from 'react';
 import { ColumnStatus } from '../columns/column-contribution-service';
 import { Decoration, MemoryDisplayConfiguration, MemoryState } from '../utils/view-types';
@@ -22,14 +21,15 @@ import { MemoryTable } from './memory-table';
 import { OptionsWidget } from './options-widget';
 import { WebviewIdMessageParticipant } from 'vscode-messenger-common';
 import { VscodeContext, createAppVscodeContext } from '../utils/vscode-contexts';
-import { WebviewSelection, MemoryOptions } from '../../common/messaging';
+import { WebviewSelection } from '../../common/messaging';
+import { MemoryOptions, ReadMemoryArguments } from '../../common/messaging';
 import { Memory } from '../../common/memory';
 import { HoverService } from '../hovers/hover-service';
 
 interface MemoryWidgetProps extends MemoryDisplayConfiguration {
     messageParticipant: WebviewIdMessageParticipant;
-    configuredReadArguments: Required<DebugProtocol.ReadMemoryArguments>;
-    activeReadArguments: Required<DebugProtocol.ReadMemoryArguments>;
+    configuredReadArguments: Required<ReadMemoryArguments>;
+    activeReadArguments: Required<ReadMemoryArguments>;
     memory?: Memory;
     title: string;
     decorations: Decoration[];
@@ -45,8 +45,8 @@ interface MemoryWidgetProps extends MemoryDisplayConfiguration {
     resetMemoryDisplayConfiguration: () => void;
     updateTitle: (title: string) => void;
     fetchMemory(partialOptions?: MemoryOptions): Promise<void>;
-    triggerStoreMemory(): void;
-    triggerApplyMemory(): void;
+    storeMemory(): void;
+    applyMemory(): void;
 }
 
 interface MemoryWidgetState {
@@ -97,8 +97,8 @@ export class MemoryWidget extends React.Component<MemoryWidgetProps, MemoryWidge
                 toggleColumn={this.props.toggleColumn}
                 toggleFrozen={this.props.toggleFrozen}
                 isFrozen={this.props.isFrozen}
-                triggerStoreMemory={this.props.triggerStoreMemory}
-                triggerApplyMemory={this.props.triggerApplyMemory}
+                storeMemory={this.props.storeMemory}
+                applyMemory={this.props.applyMemory}
             />
             <MemoryTable
                 ref={this.memoryTable}

--- a/src/webview/components/memory-widget.tsx
+++ b/src/webview/components/memory-widget.tsx
@@ -71,6 +71,7 @@ export class MemoryWidget extends React.Component<MemoryWidgetProps, MemoryWidge
             showRadixPrefix: this.props.showRadixPrefix,
             showAsciiColumn: visibleColumns.includes('ascii'),
             showVariablesColumn: visibleColumns.includes('variables'),
+            activeReadArguments: this.props.activeReadArguments
         });
 
     }

--- a/src/webview/components/memory-widget.tsx
+++ b/src/webview/components/memory-widget.tsx
@@ -17,12 +17,13 @@
 import { DebugProtocol } from '@vscode/debugprotocol';
 import React from 'react';
 import { ColumnStatus } from '../columns/column-contribution-service';
-import { Decoration, Memory, MemoryDisplayConfiguration, MemoryState } from '../utils/view-types';
+import { Decoration, MemoryDisplayConfiguration, MemoryState } from '../utils/view-types';
 import { MemoryTable } from './memory-table';
 import { OptionsWidget } from './options-widget';
 import { WebviewIdMessageParticipant } from 'vscode-messenger-common';
 import { VscodeContext, createAppVscodeContext } from '../utils/vscode-contexts';
-import { WebviewSelection } from '../../common/messaging';
+import { WebviewSelection, MemoryOptions } from '../../common/messaging';
+import { Memory } from '../../common/memory';
 import { HoverService } from '../hovers/hover-service';
 
 interface MemoryWidgetProps extends MemoryDisplayConfiguration {
@@ -43,7 +44,9 @@ interface MemoryWidgetProps extends MemoryDisplayConfiguration {
     updateMemoryDisplayConfiguration: (memoryArguments: Partial<MemoryDisplayConfiguration>) => void;
     resetMemoryDisplayConfiguration: () => void;
     updateTitle: (title: string) => void;
-    fetchMemory(partialOptions?: Partial<DebugProtocol.ReadMemoryArguments>): Promise<void>
+    fetchMemory(partialOptions?: MemoryOptions): Promise<void>;
+    triggerStoreMemory(): void;
+    triggerApplyMemory(): void;
 }
 
 interface MemoryWidgetState {
@@ -94,6 +97,8 @@ export class MemoryWidget extends React.Component<MemoryWidgetProps, MemoryWidge
                 toggleColumn={this.props.toggleColumn}
                 toggleFrozen={this.props.toggleFrozen}
                 isFrozen={this.props.isFrozen}
+                triggerStoreMemory={this.props.triggerStoreMemory}
+                triggerApplyMemory={this.props.triggerApplyMemory}
             />
             <MemoryTable
                 ref={this.memoryTable}

--- a/src/webview/components/memory-widget.tsx
+++ b/src/webview/components/memory-widget.tsx
@@ -22,12 +22,13 @@ import { OptionsWidget } from './options-widget';
 import { WebviewIdMessageParticipant } from 'vscode-messenger-common';
 import { VscodeContext, createAppVscodeContext } from '../utils/vscode-contexts';
 import { WebviewSelection } from '../../common/messaging';
-import { MemoryOptions, ReadMemoryArguments } from '../../common/messaging';
+import { MemoryOptions, ReadMemoryArguments, SessionContext } from '../../common/messaging';
 import { Memory } from '../../common/memory';
 import { HoverService } from '../hovers/hover-service';
 
 interface MemoryWidgetProps extends MemoryDisplayConfiguration {
     messageParticipant: WebviewIdMessageParticipant;
+    sessionContext: SessionContext;
     configuredReadArguments: Required<ReadMemoryArguments>;
     activeReadArguments: Required<ReadMemoryArguments>;
     memory?: Memory;
@@ -78,6 +79,7 @@ export class MemoryWidget extends React.Component<MemoryWidgetProps, MemoryWidge
         return (<div className='flex flex-column h-full' {...this.createVscodeContext()}>
             <OptionsWidget
                 ref={this.optionsWidget}
+                sessionContext={this.props.sessionContext}
                 title={this.props.title}
                 updateTitle={this.props.updateTitle}
                 columnOptions={this.props.columns}

--- a/src/webview/components/options-widget.tsx
+++ b/src/webview/components/options-widget.tsx
@@ -417,7 +417,7 @@ export class OptionsWidget extends React.Component<OptionsWidgetProps, OptionsWi
 
     protected handleKeyDown: (event: KeyboardEvent<HTMLInputElement>) => void = e => this.doHandleKeyDown(e);
     protected doHandleKeyDown(event: KeyboardEvent<HTMLInputElement>): void {
-        if (event.code === 'Enter') {
+        if (event.key === 'Enter') {
             const id = event.currentTarget.id as InputId;
             const value = event.currentTarget.value;
 

--- a/src/webview/components/options-widget.tsx
+++ b/src/webview/components/options-widget.tsx
@@ -14,7 +14,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import type { DebugProtocol } from '@vscode/debugprotocol';
 import { Formik, FormikConfig, FormikErrors, FormikProps } from 'formik';
 import { Button } from 'primereact/button';
 import { Dropdown, DropdownChangeEvent } from 'primereact/dropdown';
@@ -30,7 +29,7 @@ import { tryToNumber } from '../../common/typescript';
 import { Checkbox } from 'primereact/checkbox';
 import { Endianness } from '../../common/memory-range';
 import { createSectionVscodeContext } from '../utils/vscode-contexts';
-import { ReadMemoryArguments } from '../../common/messaging';
+import { MemoryOptions, ReadMemoryArguments } from '../../common/messaging';
 import { validateMemoryReference, validateOffset, validateCount } from '../../common/memory';
 
 export interface OptionsWidgetProps
@@ -42,12 +41,12 @@ export interface OptionsWidgetProps
     resetRenderOptions: () => void;
     updateTitle: (title: string) => void;
     updateMemoryState: (state: Partial<MemoryState>) => void;
-    fetchMemory(partialOptions?: Partial<DebugProtocol.ReadMemoryArguments>): Promise<void>
+    fetchMemory(partialOptions?: MemoryOptions): Promise<void>
     toggleColumn(id: string, isVisible: boolean): void;
     toggleFrozen: () => void;
     isFrozen: boolean;
-    triggerStoreMemory(): void;
-    triggerApplyMemory(): void;
+    storeMemory(): void;
+    applyMemory(): void;
 }
 
 interface OptionsWidgetState {
@@ -177,7 +176,7 @@ export class OptionsWidget extends React.Component<OptionsWidgetProps, OptionsWi
                                 type='button'
                                 className='store-file-button'
                                 icon='codicon codicon-save'
-                                onClick={this.props.triggerStoreMemory}
+                                onClick={this.props.storeMemory}
                                 title='Store Memory as File'
                                 aria-label='Store Memory as File'
                                 rounded
@@ -187,7 +186,7 @@ export class OptionsWidget extends React.Component<OptionsWidgetProps, OptionsWi
                                 type='button'
                                 className='apply-file-button'
                                 icon='codicon codicon-folder-opened'
-                                onClick={this.props.triggerApplyMemory}
+                                onClick={this.props.applyMemory}
                                 title='Apply Memory from File'
                                 aria-label='Apply Memory from File'
                                 rounded

--- a/src/webview/memory-webview-view.tsx
+++ b/src/webview/memory-webview-view.tsx
@@ -14,35 +14,39 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+import 'primeflex/primeflex.css';
+import { PrimeReactProvider } from 'primereact/api';
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { HOST_EXTENSION, WebviewIdMessageParticipant } from 'vscode-messenger-common';
+import { Memory, createMemoryFromRead } from '../common/memory';
+import { BigIntMemoryRange, Endianness, WrittenMemory, doOverlap, getAddressLength, getAddressString } from '../common/memory-range';
 import {
-    readyType,
-    logMessageType,
-    setOptionsType,
-    readMemoryType,
-    setTitleType,
-    setMemoryViewSettingsType,
-    resetMemoryViewSettingsType,
-    showAdvancedOptionsType,
-    getWebviewSelectionType,
+    MemoryOptions,
+    ReadMemoryArguments,
     WebviewSelection,
+    applyMemoryType,
+    getWebviewSelectionType,
+    logMessageType,
+    memoryWrittenType,
+    readMemoryType,
+    readyType,
+    resetMemoryViewSettingsType,
+    setMemoryViewSettingsType,
+    setOptionsType,
+    setTitleType,
+    showAdvancedOptionsType,
+    storeMemoryType,
 } from '../common/messaging';
-import type { DebugProtocol } from '@vscode/debugprotocol';
-import { Decoration, Memory, MemoryDisplayConfiguration, MemoryState } from './utils/view-types';
-import { MemoryWidget } from './components/memory-widget';
-import { messenger } from './view-messenger';
-import { ColumnStatus, columnContributionService } from './columns/column-contribution-service';
-import { decorationService } from './decorations/decoration-service';
-import { variableDecorator } from './variables/variable-decorations';
-import { AsciiColumn } from './columns/ascii-column';
 import { AddressColumn } from './columns/address-column';
+import { AsciiColumn } from './columns/ascii-column';
+import { ColumnStatus, columnContributionService } from './columns/column-contribution-service';
 import { DataColumn } from './columns/data-column';
-import { PrimeReactProvider } from 'primereact/api';
-import 'primeflex/primeflex.css';
-import { getAddressLength, getAddressString } from '../common/memory-range';
-import { Endianness } from '../common/memory-range';
+import { MemoryWidget } from './components/memory-widget';
+import { decorationService } from './decorations/decoration-service';
+import { Decoration, MemoryDisplayConfiguration, MemoryState } from './utils/view-types';
+import { variableDecorator } from './variables/variable-decorations';
+import { messenger } from './view-messenger';
 import { hoverService, HoverService } from './hovers/hover-service';
 import { AddressHover } from './hovers/address-hover';
 import { DataHover } from './hovers/data-hover';
@@ -68,7 +72,7 @@ const MEMORY_DISPLAY_CONFIGURATION_DEFAULTS: MemoryDisplayConfiguration = {
     addressRadix: 16,
     showRadixPrefix: true,
 };
-const DEFAULT_READ_ARGUMENTS: Required<DebugProtocol.ReadMemoryArguments> = {
+const DEFAULT_READ_ARGUMENTS: Required<ReadMemoryArguments> = {
     memoryReference: '',
     offset: 0,
     count: 256,
@@ -105,6 +109,7 @@ class App extends React.Component<{}, MemoryAppState> {
 
     public componentDidMount(): void {
         messenger.onRequest(setOptionsType, options => this.setOptions(options));
+        messenger.onNotification(memoryWrittenType, writtenMemory => this.handleWrittenMemory(writtenMemory));
         messenger.onNotification(setMemoryViewSettingsType, config => {
             if (config.visibleColumns) {
                 for (const column of columnContributionService.getColumns()) {
@@ -131,6 +136,37 @@ class App extends React.Component<{}, MemoryAppState> {
             }
         }
         hoverService.setMemoryState(this.state);
+    }
+
+    protected handleWrittenMemory(writtenMemory: WrittenMemory): void {
+        if (!this.state.memory) {
+            return;
+        }
+        if (this.state.activeReadArguments.memoryReference === writtenMemory.memoryReference) {
+            // catch simple case
+            this.updateMemoryState();
+            return;
+        }
+        try {
+            // if we are dealing with numeric addresses (and not expressions) then we can determine the overlap
+            const written: BigIntMemoryRange = {
+                startAddress: BigInt(writtenMemory.memoryReference),
+                endAddress: BigInt(writtenMemory.memoryReference) + BigInt(writtenMemory.count ?? 0)
+            };
+            const shown: BigIntMemoryRange = {
+                startAddress: this.state.memory.address,
+                endAddress: this.state.memory.address + BigInt(this.state.memory.bytes.length)
+            };
+            if (doOverlap(written, shown)) {
+                this.updateMemoryState();
+            }
+        } catch (error) {
+            // ignore and fall through
+        }
+
+        // we could try to convert any expression we may have to an address by sending an evaluation request to the DA
+        // but for now we just go with a pessimistic approach: if we are unsure, we refresh the memory
+        this.updateMemoryState();
     }
 
     public render(): React.ReactNode {
@@ -163,11 +199,13 @@ class App extends React.Component<{}, MemoryAppState> {
                 addressPadding={this.state.addressPadding}
                 addressRadix={this.state.addressRadix}
                 showRadixPrefix={this.state.showRadixPrefix}
+                triggerStoreMemory={this.requestStoreMemory}
+                triggerApplyMemory={this.requestApplyMemory}
             />
         </PrimeReactProvider>;
     }
 
-    protected updateMemoryState = (newState: Partial<MemoryState>) => this.setState(prevState => ({ ...prevState, ...newState }));
+    protected updateMemoryState = (newState?: Partial<MemoryState>) => this.setState(prevState => ({ ...prevState, ...newState }));
     protected updateMemoryDisplayConfiguration = (newState: Partial<MemoryDisplayConfiguration>) => this.setState(prevState => ({ ...prevState, ...newState }));
     protected resetMemoryDisplayConfiguration = () => messenger.sendNotification(resetMemoryViewSettingsType, HOST_EXTENSION, undefined);
     protected updateTitle = (title: string) => {
@@ -175,7 +213,7 @@ class App extends React.Component<{}, MemoryAppState> {
         messenger.sendNotification(setTitleType, HOST_EXTENSION, title);
     };
 
-    protected async setOptions(options?: Partial<DebugProtocol.ReadMemoryArguments>): Promise<void> {
+    protected async setOptions(options?: MemoryOptions): Promise<void> {
         messenger.sendRequest(logMessageType, HOST_EXTENSION, `Setting options: ${JSON.stringify(options)}`);
         if (this.state.configuredReadArguments.memoryReference === '') {
             // Only update if we have no user configured read arguments
@@ -185,8 +223,8 @@ class App extends React.Component<{}, MemoryAppState> {
         return this.fetchMemory(options);
     }
 
-    protected fetchMemory = async (partialOptions?: Partial<DebugProtocol.ReadMemoryArguments>): Promise<void> => this.doFetchMemory(partialOptions);
-    protected async doFetchMemory(partialOptions?: Partial<DebugProtocol.ReadMemoryArguments>): Promise<void> {
+    protected fetchMemory = async (partialOptions?: MemoryOptions): Promise<void> => this.doFetchMemory(partialOptions);
+    protected async doFetchMemory(partialOptions?: MemoryOptions): Promise<void> {
         if (this.state.isFrozen) {
             return;
         }
@@ -204,7 +242,8 @@ class App extends React.Component<{}, MemoryAppState> {
                 executor => executor.fetchData(completeOptions)
             ));
 
-            const memory = this.convertMemory(completeOptions, response);
+            const memory = createMemoryFromRead(response);
+
             this.setState(prev => ({
                 ...prev,
                 decorations: decorationService.decorations,
@@ -229,17 +268,6 @@ class App extends React.Component<{}, MemoryAppState> {
             this.setState(prev => ({ ...prev, isMemoryFetching: false }));
         }
 
-    }
-
-    protected convertMemory(request: Required<DebugProtocol.ReadMemoryArguments>, result: DebugProtocol.ReadMemoryResponse['body']): Memory {
-        if (!result?.data) {
-            const message = `No memory provided for address ${request.memoryReference}`
-                + `, offset ${request.offset} and count ${request.count}!`;
-            throw new Error(message);
-        }
-        const address = BigInt(result.address);
-        const bytes = Uint8Array.from(Buffer.from(result.data, 'base64'));
-        return { bytes, address };
     }
 
     protected getEffectiveAddressLength(memory?: Memory): number {
@@ -275,6 +303,14 @@ class App extends React.Component<{}, MemoryAppState> {
     protected getWebviewSelection(): WebviewSelection {
         return this.memoryWidget.current?.getWebviewSelection() ?? {};
     }
+
+    protected requestStoreMemory = (): void => {
+        messenger.sendRequest(storeMemoryType, HOST_EXTENSION, { ...this.state.activeReadArguments });
+    };
+
+    protected requestApplyMemory = async (): Promise<void> => {
+        await messenger.sendRequest(applyMemoryType, HOST_EXTENSION, undefined);
+    };
 }
 
 const container = document.getElementById('root') as Element;

--- a/src/webview/memory-webview-view.tsx
+++ b/src/webview/memory-webview-view.tsx
@@ -148,7 +148,9 @@ class App extends React.Component<{}, MemoryAppState> {
             return;
         }
         try {
-            // if we are dealing with numeric addresses (and not expressions) then we can determine the overlap
+            // If we are dealing with numeric addresses (and not expressions) then we can determine the overlap.
+            // Note that we use big int arithmetic here to determine the overlap for (start address + length) vs (memory state address + length), i.e.,
+            // we do not actually determine the end address may need to consider the size of a word in bytes
             const written: BigIntMemoryRange = {
                 startAddress: BigInt(writtenMemory.memoryReference),
                 endAddress: BigInt(writtenMemory.memoryReference) + BigInt(writtenMemory.count ?? 0)
@@ -199,8 +201,8 @@ class App extends React.Component<{}, MemoryAppState> {
                 addressPadding={this.state.addressPadding}
                 addressRadix={this.state.addressRadix}
                 showRadixPrefix={this.state.showRadixPrefix}
-                triggerStoreMemory={this.requestStoreMemory}
-                triggerApplyMemory={this.requestApplyMemory}
+                storeMemory={this.storeMemory}
+                applyMemory={this.applyMemory}
             />
         </PrimeReactProvider>;
     }
@@ -304,11 +306,11 @@ class App extends React.Component<{}, MemoryAppState> {
         return this.memoryWidget.current?.getWebviewSelection() ?? {};
     }
 
-    protected requestStoreMemory = (): void => {
-        messenger.sendRequest(storeMemoryType, HOST_EXTENSION, { ...this.state.activeReadArguments });
+    protected storeMemory = async (): Promise<void> => {
+        await messenger.sendRequest(storeMemoryType, HOST_EXTENSION, { ...this.state.activeReadArguments });
     };
 
-    protected requestApplyMemory = async (): Promise<void> => {
+    protected applyMemory = async (): Promise<void> => {
         await messenger.sendRequest(applyMemoryType, HOST_EXTENSION, undefined);
     };
 }

--- a/src/webview/utils/view-types.ts
+++ b/src/webview/utils/view-types.ts
@@ -14,17 +14,13 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import type { DebugProtocol } from '@vscode/debugprotocol';
 import deepequal from 'fast-deep-equal';
 import type * as React from 'react';
 import { areRangesEqual, BigIntMemoryRange, Endianness, Radix } from '../../common/memory-range';
 import { GroupsPerRowOption } from '../../plugin/manifest';
 import { WebviewIdMessageParticipant } from 'vscode-messenger-common';
-
-export interface Memory {
-    address: bigint;
-    bytes: Uint8Array;
-}
+import { Memory } from '../../common/memory';
+import { ReadMemoryArguments } from '../../common/messaging';
 
 export interface SerializedTableRenderOptions extends MemoryDisplayConfiguration {
     columnOptions: Array<{ label: string, doRender: boolean }>;
@@ -54,17 +50,17 @@ export interface MemoryState {
     /**
      * The user configured memory read arguments
      */
-    configuredReadArguments: Required<DebugProtocol.ReadMemoryArguments>;
+    configuredReadArguments: Required<ReadMemoryArguments>;
     /**
      * The active memory read arguments used to load the memory
      */
-    activeReadArguments: Required<DebugProtocol.ReadMemoryArguments>;
+    activeReadArguments: Required<ReadMemoryArguments>;
     memory?: Memory;
     isMemoryFetching: boolean;
 }
 
 export interface UpdateExecutor {
-    fetchData(currentViewParameters: DebugProtocol.ReadMemoryArguments): Promise<void>;
+    fetchData(currentViewParameters: ReadMemoryArguments): Promise<void>;
 }
 
 export interface StylableNodeAttributes {

--- a/src/webview/variables/variable-decorations.ts
+++ b/src/webview/variables/variable-decorations.ts
@@ -14,9 +14,8 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import type { DebugProtocol } from '@vscode/debugprotocol';
 import { HOST_EXTENSION } from 'vscode-messenger-common';
-import { getVariables } from '../../common/messaging';
+import { ReadMemoryArguments, getVariablesType } from '../../common/messaging';
 import { messenger } from '../view-messenger';
 import { Decoration, MemoryState } from '../utils/view-types';
 import { EventEmitter, IEvent } from '../utils/events';
@@ -46,9 +45,9 @@ export class VariableDecorator implements ColumnContribution, Decorator {
 
     get onDidChange(): IEvent<Decoration[]> { return this.onDidChangeEmitter.event; }
 
-    async fetchData(currentViewParameters: DebugProtocol.ReadMemoryArguments): Promise<void> {
+    async fetchData(currentViewParameters: ReadMemoryArguments): Promise<void> {
         if (!this.active || !currentViewParameters.memoryReference || !currentViewParameters.count) { return; }
-        const visibleVariables = (await messenger.sendRequest(getVariables, HOST_EXTENSION, currentViewParameters))
+        const visibleVariables = (await messenger.sendRequest(getVariablesType, HOST_EXTENSION, currentViewParameters))
             .map<BigIntVariableRange>(transmissible => {
                 const startAddress = BigInt(transmissible.startAddress);
                 return {

--- a/src/webview/variables/variable-decorations.ts
+++ b/src/webview/variables/variable-decorations.ts
@@ -25,6 +25,7 @@ import { ReactNode } from 'react';
 import { areVariablesEqual, compareBigInt, BigIntMemoryRange, BigIntVariableRange, doOverlap } from '../../common/memory-range';
 import * as React from 'react';
 import { createVariableVscodeContext } from '../utils/vscode-contexts';
+import { stringifyWithBigInts } from '../../common/typescript';
 
 const NON_HC_COLORS = [
     'var(--vscode-terminal-ansiBlue)',
@@ -135,11 +136,6 @@ export class VariableDecorator implements ColumnContribution, Decorator {
     dispose(): void {
         this.onDidChangeEmitter.dispose();
     }
-}
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function stringifyWithBigInts(object: any): any {
-    return JSON.stringify(object, (_key, value) => typeof value === 'bigint' ? value.toString() : value);
 }
 
 export const variableDecorator = new VariableDecorator();

--- a/yarn.lock
+++ b/yarn.lock
@@ -2306,6 +2306,11 @@ npm-run-path@^4.0.1:
   dependencies:
     path-key "^3.0.0"
 
+nrf-intel-hex@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/nrf-intel-hex/-/nrf-intel-hex-1.4.0.tgz#f14d5d89a09437407536652ca3a377cef915be9e"
+  integrity sha512-q3+GGRIpe0VvCjUP1zaqW5rk6IpCZzhD0lu7Sguo1bgWwFcA9kZRjsaKUb0jBQMnefyOl5o0BBGAxvqMqYx8Sg==
+
 nth-check@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-2.1.1.tgz#c9eab428effce36cd6b92c924bdb000ef1f1ed1d"
@@ -3378,6 +3383,11 @@ vscode-messenger@^0.4.3:
   integrity sha512-zOkWT/gXVvksYjtuTfGYWhc2Kn+OFDQl7w2P/LodFufC35tGo6tko28ACSJgvrIFeIhhI11XgMhlCGcT3QZGRA==
   dependencies:
     vscode-messenger-common "^0.4.3"
+
+vscode-uri@^3.0.8:
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-3.0.8.tgz#1770938d3e72588659a172d0fd4642780083ff9f"
+  integrity sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw==
 
 watchpack@^2.4.0:
   version "2.4.0"


### PR DESCRIPTION
#### What it does
Add commands to store and apply memory content as Intel HEX file
- Encapsulate behavior in new MemoryStorage class
- Trigger 'store' from Memory view, Variables view and command palette
- Trigger 'apply' from Memory view, Explorer view and command palette
- Use nrf-intel-hex library for read/write file licensed under BSD-3

Use quick inputs to guide user through necessary input
- Initialize as much of the input as possible through command args

Communicate with webview through messenger requests and notifications
- Request to trigger store and apply from webview
- Notify webview about any written memory so it can update properly

Minor improvements
- Move some common types and functionality into 'common' area
- Avoid bleeding Debug Adapter types into webview, use messaging types
- Common style: 'getVariables' -> 'getVariablesType'
- Provide utility functions and types for debug requests
- Fix 'Enter' handling for numpad by checking key value of event

https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/assets/19170971/9c3e2772-cfd5-4b7c-8d45-e2707338d0cb


Closes #50

#### How to test
- Run a debug session
- Check how you can store memory (from the inspector, from the command, from the Variables window)
- Try applying your stored memory (from the inspector, from the file context menu, from the file explorer context menu)

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
