### PR TITLE
Revert autofit smoothing introduced in PR #82 and use debouncing resize events

### DIFF
--- a/media/memory-table.css
+++ b/media/memory-table.css
@@ -23,14 +23,6 @@
   font-family: var(--vscode-editor-font-family);
 }
 
-.memory-inspector-table.groups-per-row-autofit tr > td.column-data > .data-groups-container {
-  overflow: hidden;
-  height: 1em;
-  display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
-}
-
 /* == MoreMemorySelect == */
 
 .bytes-select {

--- a/media/memory-table.css
+++ b/media/memory-table.css
@@ -23,6 +23,10 @@
   font-family: var(--vscode-editor-font-family);
 }
 
+.memory-inspector-table span.eight-bits {
+  white-space: nowrap;
+}
+
 /* == MoreMemorySelect == */
 
 .bytes-select {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@vscode/codicons": "^0.0.32",
     "fast-deep-equal": "^3.1.3",
     "formik": "^2.4.5",
+    "lodash": "^4.17.21",
     "memoize-one": "^6.0.0",
     "primeflex": "^3.3.1",
     "primereact": "^10.3.1",
@@ -45,6 +46,7 @@
     "vscode-messenger-webview": "^0.4.3"
   },
   "devDependencies": {
+    "@types/lodash": "^4.14.202",
     "@types/node": "^12.20.0",
     "@types/react": "^18.0.26",
     "@types/react-dom": "^18.0.9",

--- a/src/webview/columns/data-column.tsx
+++ b/src/webview/columns/data-column.tsx
@@ -35,7 +35,7 @@ export class DataColumn implements ColumnContribution {
     };
 
     render(range: BigIntMemoryRange, memory: Memory, options: TableRenderOptions): React.ReactNode {
-        return <div className='data-groups-container'>{this.renderGroups(range, memory, options)}</div>;
+        return this.renderGroups(range, memory, options);
     }
 
     protected renderGroups(range: BigIntMemoryRange, memory: Memory, options: TableRenderOptions): React.ReactNode {

--- a/src/webview/components/memory-table.tsx
+++ b/src/webview/components/memory-table.tsx
@@ -28,6 +28,7 @@ import { tryToNumber } from '../../common/typescript';
 import { DataColumn } from '../columns/data-column';
 import { createColumnVscodeContext, createSectionVscodeContext } from '../utils/vscode-contexts';
 import { WebviewSelection } from '../../common/messaging';
+import { debounce } from 'lodash';
 
 export interface MoreMemorySelectProps {
     activeReadArguments: Required<DebugProtocol.ReadMemoryArguments>;
@@ -199,14 +200,18 @@ export class MemoryTable extends React.PureComponent<MemoryTableProps, MemoryTab
     }
 
     componentDidMount(): void {
+        const handleResize = debounce(() => {
+            this.autofitColumns();
+
+            // The size changed - we could have too few rows visible to enable a scrollbar
+            if (this.props.scrollingBehavior === 'Auto-Append') {
+                this.ensureSufficientVisibleRowsForScrollbar();
+            }
+        }, 100);
+
         this.resizeObserver = new ResizeObserver(entries => {
             if (entries.length > 0) {
-                this.autofitColumns();
-
-                // The size changed - we could have too few rows visible to enable a scrollbar
-                if (this.props.scrollingBehavior === 'Auto-Append') {
-                    this.ensureSufficientVisibleRowsForScrollbar();
-                }
+                handleResize();
             }
         });
 

--- a/src/webview/components/memory-table.tsx
+++ b/src/webview/components/memory-table.tsx
@@ -305,7 +305,7 @@ export class MemoryTable extends React.PureComponent<MemoryTableProps, MemoryTab
     protected createDataTableProperties(rows: MemoryRowData[]): DataTableProps<MemoryRowData[]> {
         return {
             cellSelection: true,
-            className: classNames(MemoryTable.TABLE_CLASS, { [MemoryTable.TABLE_GROUPS_PER_ROW_AUTOFIT]: this.props.groupsPerRow === 'Autofit' }),
+            className: classNames(MemoryTable.TABLE_CLASS, 'overflow-hidden'),
             header: this.renderHeader(),
             lazy: true,
             metaKeySelection: false,
@@ -557,7 +557,6 @@ export class MemoryTable extends React.PureComponent<MemoryTableProps, MemoryTab
 
 export namespace MemoryTable {
     export const TABLE_CLASS = 'memory-inspector-table' as const;
-    export const TABLE_GROUPS_PER_ROW_AUTOFIT = 'groups-per-row-autofit' as const;
 
     /**
      * Approximates how many rows visually fit into the given wrapper without scrolling

--- a/yarn.lock
+++ b/yarn.lock
@@ -174,6 +174,11 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
+"@types/lodash@^4.14.202":
+  version "4.14.202"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.202.tgz#f09dbd2fb082d507178b2f2a5c7e74bd72ff98f8"
+  integrity sha512-OvlIYQK9tNneDlS0VN54LLd5uiPCBOp7gS5Z0f1mjoJYBrtStzgmJBxONW3U6OZqdtNzZPmn9BS/7WI7BFFcFQ==
+
 "@types/node@*":
   version "18.11.10"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.10.tgz#4c64759f3c2343b7e6c4b9caf761c7a3a05cee34"


### PR DESCRIPTION
#### What it does

Reverts commit 30ab368 and introduces an alternative solution

#### How to test

Commit: 62354e33629c19073b416615391aa12b146ee437 

1. Set the Bytes per Word and Words per Row to 1 and Groups per Row to Autofit
2. Decrease the width of the webview (e.g., Open the devtools and resize that)

Increasing the width of the webview: No issues - new groups will be appended
Decreasing the width of the webview: The content of the data-column will break until the autofit calculation runs.

Commit: ed152d290872744bf8859f420a77d59937905143

Now, we wait until the user stops the movement (200ms) and trigger the change afterwards. The only disadvantage we have is, that we need to wait a little.

![Peek 2024-03-08 13-05](https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/assets/13104167/f94baddb-8c23-49a4-ab8e-c2e736ce1fe0)

#### Source Problem

There is a time delay:
1. User resizes webview
2. Browser renders elements, e.g., the data-column will break lines if it can not fit anymore
3. We retrieve the resize event and trigger the autofit
4. The columns will be rendered again

Consequently, there is flickering. 

#### Alternative solution

Remove CSS solution which causes issues and execute the autofitting after the user stops with debounce. 

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
