### PR TITLE
Memory Table Editability

### DIFF
--- a/media/memory-table.css
+++ b/media/memory-table.css
@@ -27,6 +27,10 @@
   white-space: nowrap;
 }
 
+.memory-inspector-table .column-data .byte-group.editable:hover {
+  border-bottom: 1px dotted var(--vscode-editorHoverWidget-border);
+}
+
 /* == MoreMemorySelect == */
 
 .bytes-select {

--- a/package.json
+++ b/package.json
@@ -121,6 +121,11 @@
         "title": "Apply Memory from File",
         "enablement": "memory-inspector.canWrite",
         "category": "Memory"
+      },
+      {
+        "command": "memory-inspector.edit-current-selection",
+        "title": "Edit currently selected memory",
+        "enablement": "memory-inspector.canWrite && webviewId === memory-inspector.memory"
       }
     ],
     "menus": {

--- a/package.json
+++ b/package.json
@@ -200,6 +200,11 @@
           "command": "memory-inspector.apply-file",
           "group": "display@6",
           "when": "webviewId === memory-inspector.memory"
+        },
+        {
+          "command": "memory-inspector.edit-current-selection",
+          "group": "actions@1",
+          "when": "webviewId === memory-inspector.memory"
         }
       ]
     },

--- a/src/common/memory-range.ts
+++ b/src/common/memory-range.ts
@@ -121,7 +121,11 @@ export function areVariablesEqual(one: BigIntVariableRange, other: BigIntVariabl
         && one.type === other.type
         && one.value === other.value;
 }
-
+/**
+ * @param wordSize Size of an addressable unit in bits
+ *
+ * Computes the number of 8-bit bytes between two addresses
+ */
 export function toOffset(startAddress: bigint, targetAddress: bigint, wordSize: number): number {
     return Number(targetAddress - startAddress) * (wordSize / 8);
 }

--- a/src/common/messaging.ts
+++ b/src/common/messaging.ts
@@ -51,6 +51,7 @@ export const resetMemoryViewSettingsType: NotificationType<void> = { method: 're
 export const setTitleType: NotificationType<string> = { method: 'setTitle' };
 export const memoryWrittenType: NotificationType<WrittenMemory> = { method: 'memoryWritten' };
 export const sessionContextChangedType: NotificationType<SessionContext> = { method: 'sessionContextChanged' };
+export const editSelectedMemoryType: NotificationType<void> = { method: 'editSelectedMemory' };
 
 // Requests
 export const setOptionsType: RequestType<MemoryOptions, void> = { method: 'setOptions' };

--- a/src/plugin/memory-webview-main.ts
+++ b/src/plugin/memory-webview-main.ts
@@ -20,6 +20,7 @@ import { WebviewIdMessageParticipant } from 'vscode-messenger-common';
 import { Endianness, VariableRange } from '../common/memory-range';
 import {
     applyMemoryType,
+    editSelectedMemoryType,
     getVariablesType,
     getWebviewSelectionType,
     logMessageType,
@@ -70,6 +71,7 @@ export class MemoryWebview implements vscode.CustomReadonlyEditorProvider {
     public static ToggleRadixPrefixCommandType = `${manifest.PACKAGE_NAME}.toggle-radix-prefix`;
     public static ShowAdvancedDisplayConfigurationCommandType = `${manifest.PACKAGE_NAME}.show-advanced-display-options`;
     public static GetWebviewSelectionCommandType = `${manifest.PACKAGE_NAME}.get-webview-selection`;
+    public static EditCurrentSelectionCommandType = `${manifest.PACKAGE_NAME}.edit-current-selection`;
 
     protected messenger: Messenger;
     protected refreshOnStop: RefreshEnum;
@@ -110,6 +112,9 @@ export class MemoryWebview implements vscode.CustomReadonlyEditorProvider {
                 this.messenger.sendNotification(showAdvancedOptionsType, ctx.messageParticipant, undefined);
             }),
             vscode.commands.registerCommand(MemoryWebview.GetWebviewSelectionCommandType, (ctx: WebviewContext) => this.getWebviewSelection(ctx.messageParticipant)),
+            vscode.commands.registerCommand(MemoryWebview.EditCurrentSelectionCommandType, (ctx: WebviewContext) => {
+                this.messenger.sendNotification(editSelectedMemoryType, ctx.messageParticipant, undefined);
+            })
         );
     };
 

--- a/src/webview/columns/column-contribution-service.ts
+++ b/src/webview/columns/column-contribution-service.ts
@@ -48,7 +48,6 @@ export interface ColumnStatus {
 
 export interface TableRenderOptions extends Omit<SerializedTableRenderOptions, 'columnOptions'> {
     columnOptions: ColumnStatus[];
-    currentlyEditedRange?: BigIntMemoryRange;
 }
 
 class ColumnContributionService {

--- a/src/webview/columns/column-contribution-service.ts
+++ b/src/webview/columns/column-contribution-service.ts
@@ -48,6 +48,7 @@ export interface ColumnStatus {
 
 export interface TableRenderOptions extends Omit<SerializedTableRenderOptions, 'columnOptions'> {
     columnOptions: ColumnStatus[];
+    currentlyEditedRange?: BigIntMemoryRange;
 }
 
 class ColumnContributionService {

--- a/src/webview/columns/data-column.tsx
+++ b/src/webview/columns/data-column.tsx
@@ -15,13 +15,37 @@
  ********************************************************************************/
 
 import * as React from 'react';
-import { Memory } from '../../common/memory';
-import { BigIntMemoryRange, Endianness, toOffset } from '../../common/memory-range';
-import type { MemorySizeOptions } from '../components/memory-table';
-import { decorationService } from '../decorations/decoration-service';
+import { BigIntMemoryRange, Endianness, toHexStringWithRadixMarker, toOffset } from '../../common/memory-range';
 import { FullNodeAttributes } from '../utils/view-types';
-import { characterWidthInContainer, elementInnerWidth } from '../utils/window';
 import { ColumnContribution, TableRenderOptions } from './column-contribution-service';
+import { decorationService } from '../decorations/decoration-service';
+import type { MemorySizeOptions } from '../components/memory-table';
+import { elementInnerWidth, characterWidthInContainer } from '../utils/window';
+import { Memory } from '../../common/memory';
+import { HOST_EXTENSION } from 'vscode-messenger-common';
+import { messenger } from '../view-messenger';
+import { writeMemoryType } from '../../common/messaging';
+import { DebugProtocol } from '@vscode/debugprotocol';
+import { InputText } from 'primereact/inputtext';
+
+export interface DataColumnByteGroup {
+    startAddress: bigint;
+    endAddress: bigint;
+    words: DataColumnWord[];
+}
+
+export interface DataColumnWord {
+    address: bigint;
+    initialOffset: number;
+    finalOffset: number;
+    bits: DataColumnBit[];
+}
+
+export interface DataColumnBit {
+    address: bigint;
+    offset: number;
+    value: string;
+}
 
 export class DataColumn implements ColumnContribution {
     static CLASS_NAME = 'column-data';
@@ -31,66 +55,239 @@ export class DataColumn implements ColumnContribution {
     readonly label = 'Data';
     readonly priority = 1;
 
-    protected byteGroupStyle: React.CSSProperties = {
-        marginRight: `${DataColumn.Styles.MARGIN_RIGHT_PX}px`
-    };
-
     render(range: BigIntMemoryRange, memory: Memory, options: TableRenderOptions): React.ReactNode {
-        return this.renderGroups(range, memory, options);
+        const byteGroups = this.parse({ memory, range, renderOptions: options });
+        return byteGroups.map(group =>
+            <EditableDataColumnGroup key={group.startAddress.toString(16)} range={range} group={group} options={options} writeMemory={this.writeMemory}></EditableDataColumnGroup>);
     }
 
-    protected renderGroups(range: BigIntMemoryRange, memory: Memory, options: TableRenderOptions): React.ReactNode {
-        const groups = [];
-        let words: React.ReactNode[] = [];
-        for (let address = range.startAddress; address < range.endAddress; address++) {
-            words.push(this.renderWord(memory, options, address));
-            if (words.length % options.wordsPerGroup === 0) {
-                this.applyEndianness(words, options);
-                const isLast = address + 1n >= range.endAddress;
-                const style: React.CSSProperties | undefined = isLast ? undefined : this.byteGroupStyle;
-                groups.push(<span className='byte-group hoverable' data-column='data' style={style} key={address.toString(16)}>{words}</span>);
+    protected writeMemory = async (writeArguments: DebugProtocol.WriteMemoryArguments): Promise<void> => {
+        await messenger.sendRequest(writeMemoryType, HOST_EXTENSION, writeArguments);
+    };
+
+    // Parse the provided memory, so that we can separate UI from data
+    protected parse(options: { range: BigIntMemoryRange, memory: Memory, renderOptions: TableRenderOptions }): DataColumnByteGroup[] {
+        const { memory, range, renderOptions } = options;
+
+        const getBits = (address: bigint, offset: number): DataColumnBit => ({
+            address,
+            offset,
+            value: (memory.bytes[offset] ?? 0).toString(16).padStart(2, '0')
+        });
+
+        const getWords = (address: bigint): DataColumnWord => {
+            const initialOffset = toOffset(memory.address, address, renderOptions.bytesPerWord * 8);
+            const finalOffset = initialOffset + renderOptions.bytesPerWord;
+
+            const bytes: DataColumnWord = {
+                address,
+                initialOffset,
+                finalOffset,
+                bits: []
+            };
+
+            for (let i = initialOffset; i < finalOffset; i++) {
+                bytes.bits.push(getBits(address, i));
+            }
+
+            bytes.bits = this.applyEndianness(bytes.bits, renderOptions);
+            return bytes;
+        };
+
+        const byteGroups: DataColumnByteGroup[] = [];
+
+        let words: DataColumnWord[] = [];
+        let startAddress = range.startAddress;
+        for (let i = range.startAddress; i < range.endAddress; i++) {
+            words.push(getWords(i));
+            if (words.length % renderOptions.wordsPerGroup === 0) {
+                words = this.applyEndianness(words, renderOptions);
+                const endAddress = i;
+                byteGroups.push({
+                    startAddress,
+                    endAddress,
+                    words
+                });
+                startAddress = endAddress + 1n;
                 words = [];
             }
         }
-        if (words.length) { groups.push(<span className='byte-group hoverable' data-column='data' key={(range.endAddress - BigInt(words.length)).toString(16)}>{words}</span>); }
-        return groups;
-    }
 
-    protected renderWord(memory: Memory, options: TableRenderOptions, currentAddress: bigint): React.ReactNode {
-        const initialOffset = toOffset(memory.address, currentAddress, options.bytesPerWord * 8);
-        const finalOffset = initialOffset + options.bytesPerWord;
-        const bytes: React.ReactNode[] = [];
-        for (let i = initialOffset; i < finalOffset; i++) {
-            bytes.push(this.renderEightBits(memory, currentAddress, i));
-        }
-        this.applyEndianness(bytes, options);
-        return <span className='single-word' key={currentAddress.toString(16)}>{bytes}</span>;
+        if (words.length) { byteGroups.push({ startAddress, endAddress: range.endAddress, words }); }
+
+        return byteGroups;
     }
 
     protected applyEndianness<T>(group: T[], options: TableRenderOptions): T[] {
         // Assume data from the DAP comes in Big Endian so we need to revert the order if we use Little Endian
         return options.endianness === Endianness.Big ? group : group.reverse();
     }
+}
 
-    protected renderEightBits(memory: Memory, currentAddress: bigint, offset: number): React.ReactNode {
-        const { content, className, style, title } = this.getBitAttributes(memory, currentAddress, offset);
+export interface EditableDataColumnGroupProps {
+    range: BigIntMemoryRange;
+    group: DataColumnByteGroup;
+    options: TableRenderOptions;
+    writeMemory?(writeArguments: DebugProtocol.WriteMemoryArguments): Promise<void>;
+}
+
+export interface EditableDataColumnGroupState {
+    value: string;
+    isEdit: boolean;
+}
+
+export class EditableDataColumnGroup extends React.Component<EditableDataColumnGroupProps, EditableDataColumnGroupState> {
+
+    constructor(props: EditableDataColumnGroupProps) {
+        super(props);
+
+        this.state = {
+            isEdit: false,
+            value: this.asLine(this.props.group)
+        };
+    }
+
+    protected byteGroupStyle: React.CSSProperties = {
+        marginRight: `${DataColumn.Styles.MARGIN_RIGHT_PX}px`
+    };
+
+    protected get renderableCharacters(): number {
+        return this.props.options.bytesPerWord * this.props.options.wordsPerGroup * 2;
+    }
+
+    render(): React.ReactNode {
+        if (this.state.isEdit) {
+            return this.renderEditingGroup();
+        }
+
+        return this.renderReadonlyGroup();
+    }
+
+    componentDidUpdate(_prevProps: Readonly<EditableDataColumnGroupProps>, prevState: Readonly<EditableDataColumnGroupState>): void {
+        if (prevState.isEdit === false && this.state.isEdit) {
+            this.setState(prev => ({ ...prev, value: this.asLine(this.props.group) }));
+        }
+    }
+
+    protected asLine(group: DataColumnByteGroup): string {
+        return group.words.flatMap(w => w.bits.flatMap(b => b.value).join('')).join('');
+    }
+
+    protected renderEditingGroup(): React.ReactNode {
+        const { endAddress } = this.props.group;
+        const isLast = endAddress === this.props.range.endAddress;
+
+        const style: React.CSSProperties = {
+            ...decorationService.getDecoration(this.props.group.startAddress)?.style,
+            width: `calc(${this.renderableCharacters}ch + 10px)`,
+            padding: '0 4px',
+            marginRight: isLast ? undefined : this.byteGroupStyle.marginRight,
+            minHeight: 'unset',
+            border: '1px solid var(--vscode-inputOption-activeBorder)',
+            background: 'unset'
+        };
+
+        return <InputText key={this.props.group.startAddress.toString(16)}
+            maxLength={this.renderableCharacters}
+            value={this.state.value}
+            onKeyDown={this.onKeyDown}
+            onChange={this.onChange}
+            autoFocus
+            style={style}
+            onBlur={this.onBlur}
+        ></InputText>;
+    }
+
+    protected renderReadonlyGroup(): React.ReactNode {
+        const { startAddress, endAddress, words } = this.props.group;
+        const isLast = endAddress === this.props.range.endAddress;
+        const style: React.CSSProperties | undefined = isLast ? undefined : this.byteGroupStyle;
+        return <span className='byte-group editable' style={style} key={startAddress.toString(16)} onClick={this.enableEdit}>{
+            words.map(w => this.renderWord(w))
+        }</span>;
+    }
+
+    protected renderWord(word: DataColumnWord): React.ReactNode {
+        return <span className='single-word' key={word.address.toString(16)}>{
+            word.bits.map(b => this.renderEightBits(b))
+        }</span>;
+    }
+
+    protected renderEightBits(bit: DataColumnBit): React.ReactNode {
+        const { content, className, style, title } = this.getBitAttributes(bit);
         return <span
             style={style}
-            key={offset.toString(16)}
+            key={bit.offset.toString(16)}
             className={className}
-            data-id={offset}
+            data-id={bit.offset}
             title={title}
         >
             {content}
         </span>;
     }
 
-    protected getBitAttributes(memory: Memory, currentAdress: bigint, offset: number): FullNodeAttributes {
+    protected getBitAttributes(bit: DataColumnBit): FullNodeAttributes {
         return {
             className: 'eight-bits',
-            style: decorationService.getDecoration(currentAdress)?.style,
-            content: (memory.bytes[offset] ?? 0).toString(16).padStart(2, '0')
+            style: decorationService.getDecoration(bit.address)?.style,
+            content: bit.value
         };
+    }
+
+    protected enableEdit: React.MouseEventHandler = event => {
+        this.setState(prev => ({ ...prev, isEdit: true }));
+        event.stopPropagation();
+    };
+
+    protected disableEdit = () => {
+        this.setState(prev => ({ ...prev, isEdit: false, value: this.asLine(this.props.group) }));
+    };
+
+    protected onBlur: React.FocusEventHandler<HTMLInputElement> = () => {
+        this.disableEdit();
+        this.submitChanges();
+    };
+
+    protected onKeyDown: React.KeyboardEventHandler<HTMLInputElement> = event => {
+        switch (event.key) {
+            case 'Escape': {
+                this.disableEdit();
+                break;
+            }
+            case 'Enter': {
+                this.submitChanges();
+            }
+        }
+        event.stopPropagation();
+    };
+
+    protected onChange: React.ChangeEventHandler<HTMLInputElement> = event => {
+        this.setState(prev => ({ ...prev, value: event.target.value }));
+    };
+
+    protected async submitChanges(): Promise<void> {
+        const newData = this.processData(this.state.value);
+        const original = this.processData(this.asLine(this.props.group));
+
+        if (newData && newData !== original) {
+            const converted = Buffer.from(newData, 'hex').toString('base64');
+            await this.props.writeMemory?.({
+                memoryReference: toHexStringWithRadixMarker(this.props.group.startAddress),
+                data: converted
+            });
+        }
+
+        this.disableEdit();
+    }
+
+    protected processData(data: string): string {
+        // Revert Endianness
+        if (this.props.options.endianness === Endianness.Little) {
+            const chunks = data.padStart(this.renderableCharacters, '0').match(/.{1,2}/g) || [];
+            return chunks.reverse().join('');
+        }
+
+        return data.padStart(this.renderableCharacters, '0');
     }
 }
 

--- a/src/webview/columns/data-column.tsx
+++ b/src/webview/columns/data-column.tsx
@@ -14,19 +14,19 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import * as React from 'react';
-import { BigIntMemoryRange, Endianness, isWithin, toHexStringWithRadixMarker, toOffset } from '../../common/memory-range';
-import { Disposable, FullNodeAttributes } from '../utils/view-types';
-import { ColumnContribution, TableRenderOptions } from './column-contribution-service';
-import { decorationService } from '../decorations/decoration-service';
-import type { MemorySizeOptions } from '../components/memory-table';
-import { elementInnerWidth, characterWidthInContainer } from '../utils/window';
-import { Memory } from '../../common/memory';
-import { HOST_EXTENSION } from 'vscode-messenger-common';
-import { messenger } from '../view-messenger';
-import { writeMemoryType } from '../../common/messaging';
 import { InputText } from 'primereact/inputtext';
+import * as React from 'react';
+import { HOST_EXTENSION } from 'vscode-messenger-common';
+import { Memory } from '../../common/memory';
+import { BigIntMemoryRange, Endianness, isWithin, toHexStringWithRadixMarker, toOffset } from '../../common/memory-range';
+import { writeMemoryType } from '../../common/messaging';
+import type { MemorySizeOptions } from '../components/memory-table';
+import { decorationService } from '../decorations/decoration-service';
 import { EventEmitter } from '../utils/events';
+import { Disposable, FullNodeAttributes } from '../utils/view-types';
+import { characterWidthInContainer, elementInnerWidth } from '../utils/window';
+import { messenger } from '../view-messenger';
+import { ColumnContribution, TableRenderOptions } from './column-contribution-service';
 
 function getSelectionEdit(): BigIntMemoryRange | undefined {
     const selectionRange = document.getSelection();

--- a/src/webview/memory-webview-view.tsx
+++ b/src/webview/memory-webview-view.tsx
@@ -15,46 +15,46 @@
  ********************************************************************************/
 
 import 'primeflex/primeflex.css';
+import { debounce } from 'lodash';
 import { PrimeReactProvider } from 'primereact/api';
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { HOST_EXTENSION, WebviewIdMessageParticipant } from 'vscode-messenger-common';
-import { Memory, createMemoryFromRead } from '../common/memory';
-import { BigIntMemoryRange, Endianness, WrittenMemory, doOverlap, getAddressLength, getAddressString } from '../common/memory-range';
+import { createMemoryFromRead, Memory } from '../common/memory';
+import { BigIntMemoryRange, doOverlap, Endianness, getAddressLength, getAddressString, WrittenMemory } from '../common/memory-range';
 import {
-    MemoryOptions,
-    ReadMemoryArguments,
-    WebviewSelection,
     applyMemoryType,
+    editSelectedMemoryType,
     getWebviewSelectionType,
     logMessageType,
+    MemoryOptions,
     memoryWrittenType,
+    ReadMemoryArguments,
     readMemoryType,
     readyType,
     resetMemoryViewSettingsType,
+    SessionContext,
+    sessionContextChangedType,
     setMemoryViewSettingsType,
     setOptionsType,
     setTitleType,
     showAdvancedOptionsType,
     storeMemoryType,
-    sessionContextChangedType,
-    SessionContext,
-    editSelectedMemoryType,
+    WebviewSelection,
 } from '../common/messaging';
 import { AddressColumn } from './columns/address-column';
 import { AsciiColumn } from './columns/ascii-column';
-import { ColumnStatus, columnContributionService } from './columns/column-contribution-service';
+import { columnContributionService, ColumnStatus } from './columns/column-contribution-service';
 import { DataColumn } from './columns/data-column';
 import { MemoryWidget } from './components/memory-widget';
 import { decorationService } from './decorations/decoration-service';
+import { AddressHover } from './hovers/address-hover';
+import { DataHover } from './hovers/data-hover';
+import { hoverService, HoverService } from './hovers/hover-service';
+import { VariableHover } from './hovers/variable-hover';
 import { Decoration, MemoryDisplayConfiguration, MemoryState } from './utils/view-types';
 import { variableDecorator } from './variables/variable-decorations';
 import { messenger } from './view-messenger';
-import { hoverService, HoverService } from './hovers/hover-service';
-import { AddressHover } from './hovers/address-hover';
-import { DataHover } from './hovers/data-hover';
-import { VariableHover } from './hovers/variable-hover';
-import { debounce } from 'lodash';
 
 export interface MemoryAppState extends MemoryState, MemoryDisplayConfiguration {
     messageParticipant: WebviewIdMessageParticipant;

--- a/src/webview/memory-webview-view.tsx
+++ b/src/webview/memory-webview-view.tsx
@@ -15,45 +15,46 @@
  ********************************************************************************/
 
 import 'primeflex/primeflex.css';
-import { debounce } from 'lodash';
 import { PrimeReactProvider } from 'primereact/api';
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { HOST_EXTENSION, WebviewIdMessageParticipant } from 'vscode-messenger-common';
-import { createMemoryFromRead, Memory } from '../common/memory';
-import { BigIntMemoryRange, doOverlap, Endianness, getAddressLength, getAddressString, WrittenMemory } from '../common/memory-range';
+import { Memory, createMemoryFromRead } from '../common/memory';
+import { BigIntMemoryRange, Endianness, WrittenMemory, doOverlap, getAddressLength, getAddressString } from '../common/memory-range';
 import {
+    MemoryOptions,
+    ReadMemoryArguments,
+    WebviewSelection,
     applyMemoryType,
     getWebviewSelectionType,
     logMessageType,
-    MemoryOptions,
     memoryWrittenType,
-    ReadMemoryArguments,
     readMemoryType,
     readyType,
     resetMemoryViewSettingsType,
-    SessionContext,
-    sessionContextChangedType,
     setMemoryViewSettingsType,
     setOptionsType,
     setTitleType,
     showAdvancedOptionsType,
     storeMemoryType,
-    WebviewSelection,
+    sessionContextChangedType,
+    SessionContext,
+    editSelectedMemoryType,
 } from '../common/messaging';
 import { AddressColumn } from './columns/address-column';
 import { AsciiColumn } from './columns/ascii-column';
-import { columnContributionService, ColumnStatus } from './columns/column-contribution-service';
+import { ColumnStatus, columnContributionService } from './columns/column-contribution-service';
 import { DataColumn } from './columns/data-column';
 import { MemoryWidget } from './components/memory-widget';
 import { decorationService } from './decorations/decoration-service';
-import { AddressHover } from './hovers/address-hover';
-import { DataHover } from './hovers/data-hover';
-import { hoverService, HoverService } from './hovers/hover-service';
-import { VariableHover } from './hovers/variable-hover';
 import { Decoration, MemoryDisplayConfiguration, MemoryState } from './utils/view-types';
 import { variableDecorator } from './variables/variable-decorations';
 import { messenger } from './view-messenger';
+import { hoverService, HoverService } from './hovers/hover-service';
+import { AddressHover } from './hovers/address-hover';
+import { DataHover } from './hovers/data-hover';
+import { VariableHover } from './hovers/variable-hover';
+import { debounce } from 'lodash';
 
 export interface MemoryAppState extends MemoryState, MemoryDisplayConfiguration {
     messageParticipant: WebviewIdMessageParticipant;
@@ -135,6 +136,7 @@ class App extends React.Component<{}, MemoryAppState> {
         messenger.onRequest(getWebviewSelectionType, () => this.getWebviewSelection());
         messenger.onNotification(showAdvancedOptionsType, () => this.showAdvancedOptions());
         messenger.sendNotification(readyType, HOST_EXTENSION, undefined);
+        messenger.onNotification(editSelectedMemoryType, () => DataColumn.editCurrentSelection());
     }
 
     public componentDidUpdate(_: {}, prevState: MemoryAppState): void {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/blob/main/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

An alternative implementation of #108 that allows both editing by group (by double clicking on the group) and editing of sub- and supra-group editing by selection and context menu.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

> As in #108:

1. Double click on a data group within the table
2. Provide a different value
3. submit with enter or blur the element
4. Changes should be applied

> In addition:

1. Select text in a data column row.
2. Use the context menu and select `Edit currently selected memory`
3. All words whose text was included in the selection will be converted into a text input.

![image](https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/assets/62660806/7fcc767b-b2de-440a-86b9-c2773cee8962)

![image](https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/assets/62660806/958545b9-22f7-4679-9db5-424f0a54a89d)

![image](https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/assets/62660806/d2a536be-5591-4747-a804-5b1437ccd462)

#### Review checklist

- [ ] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
