### PR TITLE
Rename word to MAU and add link to settings docs

### DIFF
--- a/media/options-widget.css
+++ b/media/options-widget.css
@@ -137,3 +137,12 @@
   background-color: transparent;
   cursor: pointer;
 }
+
+.no-text-decoration {
+  text-decoration: none;
+}
+
+.option-help-icon {
+  color: var(--vscode-button-background);
+  margin-left: 0.2em;
+}

--- a/package.json
+++ b/package.json
@@ -255,7 +255,7 @@
           "default": "on",
           "description": "Refresh memory views when debugger stops"
         },
-        "memory-inspector.groupings.bytesPerWord": {
+        "memory-inspector.groupings.bytesPerMAU": {
           "type": "number",
           "enum": [
             1,
@@ -265,9 +265,9 @@
             16
           ],
           "default": 1,
-          "description": "Default bytes per word"
+          "description": "Default bytes per MAU (Minimum Addressable Unit)"
         },
-        "memory-inspector.groupings.wordsPerGroup": {
+        "memory-inspector.groupings.MAUsPerGroup": {
           "type": "number",
           "enum": [
             1,
@@ -277,7 +277,7 @@
             16
           ],
           "default": 1,
-          "description": "Default words per group"
+          "description": "Default MAUs (Minimum Addressable Units) per group"
         },
         "memory-inspector.groupings.groupsPerRow": {
           "type": [

--- a/src/common/memory-range.ts
+++ b/src/common/memory-range.ts
@@ -122,8 +122,8 @@ export function areVariablesEqual(one: BigIntVariableRange, other: BigIntVariabl
         && one.value === other.value;
 }
 
-export function toOffset(startAddress: bigint, targetAddress: bigint, wordSize: number): number {
-    return Number(targetAddress - startAddress) * (wordSize / 8);
+export function toOffset(startAddress: bigint, targetAddress: bigint, mauSize: number): number {
+    return Number(targetAddress - startAddress) * (mauSize / 8);
 }
 
 export enum Endianness {

--- a/src/plugin/manifest.ts
+++ b/src/plugin/manifest.ts
@@ -29,16 +29,16 @@ export const DEFAULT_DEBUG_TYPES = ['gdb', 'embedded-debug', 'arm-debugger'];
 export const CONFIG_REFRESH_ON_STOP = 'refreshOnStop';
 export const DEFAULT_REFRESH_ON_STOP = 'on';
 
-// Words
-// - Bytes per Word
-export const CONFIG_BYTES_PER_WORD = 'groupings.bytesPerWord';
-export const CONFIG_BYTES_PER_WORD_CHOICES = [1, 2, 4, 8, 16] as const;
-export const DEFAULT_BYTES_PER_WORD = 1;
+// MAUs (Minimum Addressable Units)
+// - Bytes per MAU
+export const CONFIG_BYTES_PER_MAU = 'groupings.bytesPerMAU';
+export const CONFIG_BYTES_PER_MAU_CHOICES = [1, 2, 4, 8, 16] as const;
+export const DEFAULT_BYTES_PER_MAU = 1;
 
-// - Words per Group
-export const CONFIG_WORDS_PER_GROUP = 'groupings.wordsPerGroup';
-export const CONFIG_WORDS_PER_GROUP_CHOICES = [1, 2, 4, 8, 16] as const;
-export const DEFAULT_WORDS_PER_GROUP = 1;
+// - MAU per Group
+export const CONFIG_MAUS_PER_GROUP = 'groupings.MAUsPerGroup';
+export const CONFIG_MAUS_PER_GROUP_CHOICES = [1, 2, 4, 8, 16] as const;
+export const DEFAULT_MAUS_PER_GROUP = 1;
 
 // - Groups per Row
 export const CONFIG_GROUPS_PER_ROW = 'groupings.groupsPerRow';

--- a/src/plugin/memory-webview-main.ts
+++ b/src/plugin/memory-webview-main.ts
@@ -255,8 +255,8 @@ export class MemoryWebview implements vscode.CustomReadonlyEditorProvider {
 
     protected getMemoryViewSettings(messageParticipant: WebviewIdMessageParticipant, title: string): MemoryViewSettings {
         const memoryInspectorConfiguration = vscode.workspace.getConfiguration(manifest.PACKAGE_NAME);
-        const bytesPerWord = memoryInspectorConfiguration.get<number>(manifest.CONFIG_BYTES_PER_WORD, manifest.DEFAULT_BYTES_PER_WORD);
-        const wordsPerGroup = memoryInspectorConfiguration.get<number>(manifest.CONFIG_WORDS_PER_GROUP, manifest.DEFAULT_WORDS_PER_GROUP);
+        const bytesPerMau = memoryInspectorConfiguration.get<number>(manifest.CONFIG_BYTES_PER_MAU, manifest.DEFAULT_BYTES_PER_MAU);
+        const mausPerGroup = memoryInspectorConfiguration.get<number>(manifest.CONFIG_MAUS_PER_GROUP, manifest.DEFAULT_MAUS_PER_GROUP);
         const groupsPerRow = memoryInspectorConfiguration.get<manifest.GroupsPerRowOption>(manifest.CONFIG_GROUPS_PER_ROW, manifest.DEFAULT_GROUPS_PER_ROW);
         const endianness = memoryInspectorConfiguration.get<Endianness>(manifest.CONFIG_ENDIANNESS, manifest.DEFAULT_ENDIANNESS);
         const scrollingBehavior = memoryInspectorConfiguration.get<ScrollingBehavior>(manifest.CONFIG_SCROLLING_BEHAVIOR, manifest.DEFAULT_SCROLLING_BEHAVIOR);
@@ -267,7 +267,7 @@ export class MemoryWebview implements vscode.CustomReadonlyEditorProvider {
         const addressRadix = memoryInspectorConfiguration.get<number>(manifest.CONFIG_ADDRESS_RADIX, manifest.DEFAULT_ADDRESS_RADIX);
         const showRadixPrefix = memoryInspectorConfiguration.get<boolean>(manifest.CONFIG_SHOW_RADIX_PREFIX, manifest.DEFAULT_SHOW_RADIX_PREFIX);
         return {
-            messageParticipant, title, bytesPerWord, wordsPerGroup, groupsPerRow,
+            messageParticipant, title, bytesPerMau, mausPerGroup, groupsPerRow,
             endianness, scrollingBehavior, visibleColumns, addressPadding, addressRadix, showRadixPrefix
         };
     }

--- a/src/webview/columns/ascii-column.ts
+++ b/src/webview/columns/ascii-column.ts
@@ -33,9 +33,9 @@ export class AsciiColumn implements ColumnContribution {
     readonly label = 'ASCII';
     readonly priority = 3;
     render(range: BigIntMemoryRange, memory: Memory, options: TableRenderOptions): ReactNode {
-        const wordSize = options.bytesPerWord * 8;
-        const startOffset = toOffset(memory.address, range.startAddress, wordSize);
-        const endOffset = toOffset(memory.address, range.endAddress, wordSize);
+        const mauSize = options.bytesPerMau * 8;
+        const startOffset = toOffset(memory.address, range.startAddress, mauSize);
+        const endOffset = toOffset(memory.address, range.endAddress, mauSize);
         let result = '';
         for (let i = startOffset; i < endOffset; i++) {
             result += getASCIIForSingleByte(memory.bytes[i]);

--- a/src/webview/columns/data-column.tsx
+++ b/src/webview/columns/data-column.tsx
@@ -41,30 +41,30 @@ export class DataColumn implements ColumnContribution {
 
     protected renderGroups(range: BigIntMemoryRange, memory: Memory, options: TableRenderOptions): React.ReactNode {
         const groups = [];
-        let words: React.ReactNode[] = [];
+        let maus: React.ReactNode[] = [];
         for (let address = range.startAddress; address < range.endAddress; address++) {
-            words.push(this.renderWord(memory, options, address));
-            if (words.length % options.wordsPerGroup === 0) {
-                this.applyEndianness(words, options);
+            maus.push(this.renderMau(memory, options, address));
+            if (maus.length % options.mausPerGroup === 0) {
+                this.applyEndianness(maus, options);
                 const isLast = address + 1n >= range.endAddress;
                 const style: React.CSSProperties | undefined = isLast ? undefined : this.byteGroupStyle;
-                groups.push(<span className='byte-group hoverable' data-column='data' style={style} key={address.toString(16)}>{words}</span>);
-                words = [];
+                groups.push(<span className='byte-group hoverable' data-column='data' style={style} key={address.toString(16)}>{maus}</span>);
+                maus = [];
             }
         }
-        if (words.length) { groups.push(<span className='byte-group hoverable' data-column='data' key={(range.endAddress - BigInt(words.length)).toString(16)}>{words}</span>); }
+        if (maus.length) { groups.push(<span className='byte-group hoverable' data-column='data' key={(range.endAddress - BigInt(maus.length)).toString(16)}>{maus}</span>); }
         return groups;
     }
 
-    protected renderWord(memory: Memory, options: TableRenderOptions, currentAddress: bigint): React.ReactNode {
-        const initialOffset = toOffset(memory.address, currentAddress, options.bytesPerWord * 8);
-        const finalOffset = initialOffset + options.bytesPerWord;
+    protected renderMau(memory: Memory, options: TableRenderOptions, currentAddress: bigint): React.ReactNode {
+        const initialOffset = toOffset(memory.address, currentAddress, options.bytesPerMau * 8);
+        const finalOffset = initialOffset + options.bytesPerMau;
         const bytes: React.ReactNode[] = [];
         for (let i = initialOffset; i < finalOffset; i++) {
             bytes.push(this.renderEightBits(memory, currentAddress, i));
         }
         this.applyEndianness(bytes, options);
-        return <span className='single-word' key={currentAddress.toString(16)}>{bytes}</span>;
+        return <span className='single-mau' key={currentAddress.toString(16)}>{bytes}</span>;
     }
 
     protected applyEndianness<T>(group: T[], options: TableRenderOptions): T[] {
@@ -118,8 +118,8 @@ export namespace DataColumn {
         const charactersWidth = Math.round((characterWidthInContainer(element, '0') + Number.EPSILON) * 100) / 100;
         const groupWidth = charactersWidth
             * 2 // characters per byte
-            * options.bytesPerWord
-            * options.wordsPerGroup
+            * options.bytesPerMau
+            * options.mausPerGroup
             + Styles.MARGIN_RIGHT_PX;
         // Accommodate the non-existent margin of the final element.
         const maxGroups = Math.max((columnWidth + Styles.MARGIN_RIGHT_PX) / groupWidth, 1);

--- a/src/webview/components/memory-table.tsx
+++ b/src/webview/components/memory-table.tsx
@@ -142,8 +142,8 @@ interface MemoryTableProps extends TableRenderOptions, MemoryDisplayConfiguratio
 
 interface MemoryRowListOptions {
     numRows: number;
-    wordsPerRow: number;
-    bigWordsPerRow: bigint;
+    mausPerRow: number;
+    bigMausPerRow: bigint;
 }
 
 interface MemoryRowData {
@@ -165,14 +165,14 @@ interface MemoryTableState {
     hoverContent: React.ReactNode;
 }
 
-export type MemorySizeOptions = Pick<MemoryTableProps, 'bytesPerWord' | 'wordsPerGroup'> & { groupsPerRow: number };
+export type MemorySizeOptions = Pick<MemoryTableProps, 'bytesPerMau' | 'mausPerGroup'> & { groupsPerRow: number };
 export namespace MemorySizeOptions {
     export function create(props: MemoryTableProps, state: MemoryTableState): MemorySizeOptions {
-        const { bytesPerWord, wordsPerGroup } = props;
+        const { bytesPerMau, mausPerGroup } = props;
         return {
-            bytesPerWord,
+            bytesPerMau,
             groupsPerRow: tryToNumber(props.groupsPerRow) ?? state.groupsPerRowToRender,
-            wordsPerGroup
+            mausPerGroup
         };
     }
 }
@@ -234,7 +234,7 @@ export class MemoryTable extends React.PureComponent<MemoryTableProps, MemoryTab
             || prevProps.activeReadArguments.offset !== this.props.activeReadArguments.offset
             || prevProps.activeReadArguments.count !== this.props.activeReadArguments.count;
 
-        const hasOptionsChanged = prevProps.wordsPerGroup !== this.props.wordsPerGroup || prevProps.groupsPerRow !== this.props.groupsPerRow;
+        const hasOptionsChanged = prevProps.mausPerGroup !== this.props.mausPerGroup || prevProps.groupsPerRow !== this.props.groupsPerRow;
 
         // Reset selection
         const selection = this.state.selection;
@@ -388,7 +388,7 @@ export class MemoryTable extends React.PureComponent<MemoryTableProps, MemoryTab
         if (!this.isLoading && this.props.memory !== undefined) {
             const memorySizeOptions = MemorySizeOptions.create(this.props, this.state);
             const options = this.createMemoryRowListOptions(this.props.memory, memorySizeOptions);
-            const newCount = this.props.activeReadArguments.count + options.wordsPerRow * MemoryTable.renderableRowsAtOnceCountForWrapper(this.datatableWrapper);
+            const newCount = this.props.activeReadArguments.count + options.mausPerRow * MemoryTable.renderableRowsAtOnceCountForWrapper(this.datatableWrapper);
             this.props.fetchMemory({ count: newCount });
         }
     }
@@ -510,7 +510,7 @@ export class MemoryTable extends React.PureComponent<MemoryTableProps, MemoryTab
     protected createTableRows = memoize((memory: Memory, options: MemoryRowListOptions): MemoryRowData[] => {
         const rows: MemoryRowData[] = [];
         for (let i = 0; i < options.numRows; i++) {
-            const startAddress = memory.address + options.bigWordsPerRow * BigInt(i);
+            const startAddress = memory.address + options.bigMausPerRow * BigInt(i);
             rows.push(this.createMemoryRow(i, startAddress, options));
         }
 
@@ -518,22 +518,18 @@ export class MemoryTable extends React.PureComponent<MemoryTableProps, MemoryTab
     }, isDeepEqual);
 
     protected createMemoryRowListOptions(memory: Memory, options: MemorySizeOptions): MemoryRowListOptions {
-        const wordsPerRow = options.wordsPerGroup * options.groupsPerRow;
-        const numRows = Math.ceil((memory.bytes.length) / (wordsPerRow * options.bytesPerWord));
-        const bigWordsPerRow = BigInt(wordsPerRow);
+        const mausPerRow = options.mausPerGroup * options.groupsPerRow;
+        const numRows = Math.ceil((memory.bytes.length) / (mausPerRow * options.bytesPerMau));
+        const bigMausPerRow = BigInt(mausPerRow);
 
-        return {
-            numRows,
-            wordsPerRow,
-            bigWordsPerRow
-        };
+        return { numRows, mausPerRow, bigMausPerRow };
     };
 
     protected createMemoryRow(rowIndex: number, startAddress: bigint, memoryTableOptions: MemoryRowListOptions): MemoryRowData {
         return {
             rowIndex,
             startAddress,
-            endAddress: startAddress + memoryTableOptions.bigWordsPerRow
+            endAddress: startAddress + memoryTableOptions.bigMausPerRow
         };
     }
 

--- a/src/webview/components/memory-widget.tsx
+++ b/src/webview/components/memory-widget.tsx
@@ -87,8 +87,8 @@ export class MemoryWidget extends React.Component<MemoryWidgetProps, MemoryWidge
                 configuredReadArguments={this.props.configuredReadArguments}
                 activeReadArguments={this.props.activeReadArguments}
                 endianness={this.props.endianness}
-                bytesPerWord={this.props.bytesPerWord}
-                wordsPerGroup={this.props.wordsPerGroup}
+                bytesPerMau={this.props.bytesPerMau}
+                mausPerGroup={this.props.mausPerGroup}
                 groupsPerRow={this.props.groupsPerRow}
                 updateMemoryState={this.props.updateMemoryState}
                 updateRenderOptions={this.props.updateMemoryDisplayConfiguration}
@@ -112,8 +112,8 @@ export class MemoryWidget extends React.Component<MemoryWidgetProps, MemoryWidge
                 columnOptions={this.props.columns.filter(candidate => candidate.active)}
                 memory={this.props.memory}
                 endianness={this.props.endianness}
-                bytesPerWord={this.props.bytesPerWord}
-                wordsPerGroup={this.props.wordsPerGroup}
+                bytesPerMau={this.props.bytesPerMau}
+                mausPerGroup={this.props.mausPerGroup}
                 groupsPerRow={this.props.groupsPerRow}
                 effectiveAddressLength={this.props.effectiveAddressLength}
                 fetchMemory={this.props.fetchMemory}

--- a/src/webview/components/options-widget.tsx
+++ b/src/webview/components/options-widget.tsx
@@ -26,7 +26,7 @@ import { validateCount, validateMemoryReference, validateOffset } from '../../co
 import { Endianness } from '../../common/memory-range';
 import { MemoryOptions, ReadMemoryArguments, SessionContext } from '../../common/messaging';
 import { tryToNumber } from '../../common/typescript';
-import { CONFIG_BYTES_PER_WORD_CHOICES, CONFIG_GROUPS_PER_ROW_CHOICES, CONFIG_WORDS_PER_GROUP_CHOICES } from '../../plugin/manifest';
+import { CONFIG_BYTES_PER_MAU_CHOICES, CONFIG_GROUPS_PER_ROW_CHOICES, CONFIG_MAUS_PER_GROUP_CHOICES } from '../../plugin/manifest';
 import { TableRenderOptions } from '../columns/column-contribution-service';
 import { AddressPaddingOptions, MemoryState, SerializedTableRenderOptions } from '../utils/view-types';
 import { createSectionVscodeContext } from '../utils/vscode-contexts';
@@ -58,8 +58,8 @@ const enum InputId {
     Address = 'address',
     Offset = 'offset',
     Length = 'length',
-    BytesPerWord = 'word-size',
-    WordsPerGroup = 'words-per-group',
+    BytesPerMau = 'mau-size',
+    MausPerGroup = 'maus-per-group',
     GroupsPerRow = 'groups-per-row',
     EndiannessId = 'endianness',
     AddressPadding = 'address-padding',
@@ -304,31 +304,38 @@ export class OptionsWidget extends React.Component<OptionsWidgetProps, OptionsWi
                                 />
                             )}
 
-                            <h2>Memory Format</h2>
+                            <h2>Memory Format
+                                <a
+                                    href='https://github.com/eclipse-cdt-cloud/vscode-memory-inspector?tab=readme-ov-file#memory-format-settings'
+                                    className='no-text-decoration'
+                                >
+                                    <span className='codicon codicon-question option-help-icon'></span>
+                                </a>
+                            </h2>
                             <label
-                                htmlFor={InputId.BytesPerWord}
+                                htmlFor={InputId.BytesPerMau}
                                 className='advanced-options-label mt-1'
                             >
-                                Bytes per Word
+                                Bytes per <abbr className='no-text-decoration' title='Minimum Addressable Unit'>MAU</abbr>
                             </label>
                             <Dropdown
-                                id={InputId.BytesPerWord}
-                                value={this.props.bytesPerWord}
+                                id={InputId.BytesPerMau}
+                                value={this.props.bytesPerMau}
                                 onChange={this.handleAdvancedOptionsDropdownChange}
-                                options={[...CONFIG_BYTES_PER_WORD_CHOICES]}
+                                options={[...CONFIG_BYTES_PER_MAU_CHOICES]}
                                 className='advanced-options-dropdown' />
 
                             <label
-                                htmlFor={InputId.WordsPerGroup}
+                                htmlFor={InputId.MausPerGroup}
                                 className='advanced-options-label mt-1'
                             >
-                                Words per Group
+                                <abbr className='no-text-decoration' title='Minimum Addressable Units'>MAUs</abbr> per Group
                             </label>
                             <Dropdown
-                                id={InputId.WordsPerGroup}
-                                value={this.props.wordsPerGroup}
+                                id={InputId.MausPerGroup}
+                                value={this.props.mausPerGroup}
                                 onChange={this.handleAdvancedOptionsDropdownChange}
-                                options={[...CONFIG_WORDS_PER_GROUP_CHOICES]}
+                                options={[...CONFIG_MAUS_PER_GROUP_CHOICES]}
                                 className='advanced-options-dropdown' />
                             <label
                                 htmlFor={InputId.GroupsPerRow}
@@ -466,11 +473,11 @@ export class OptionsWidget extends React.Component<OptionsWidgetProps, OptionsWi
         const id = event.target.id as InputId;
         const value = event.target.value;
         switch (id) {
-            case InputId.BytesPerWord:
-                this.props.updateRenderOptions({ bytesPerWord: Number(value) });
+            case InputId.BytesPerMau:
+                this.props.updateRenderOptions({ bytesPerMau: Number(value) });
                 break;
-            case InputId.WordsPerGroup:
-                this.props.updateRenderOptions({ wordsPerGroup: Number(value) });
+            case InputId.MausPerGroup:
+                this.props.updateRenderOptions({ mausPerGroup: Number(value) });
                 break;
             case InputId.GroupsPerRow:
                 this.props.updateRenderOptions({ groupsPerRow: tryToNumber(value) ?? value });

--- a/src/webview/hovers/variable-hover.tsx
+++ b/src/webview/hovers/variable-hover.tsx
@@ -23,20 +23,20 @@ export class VariableHover implements HoverContribution {
     priority = 0;
 
     async render(
-        { columnId, bytesPerWord, extraData }: MemoryDetails,
+        { columnId, bytesPerMau, extraData }: MemoryDetails,
     ): Promise<React.ReactNode> {
         if (columnId !== 'variables') { return; }
 
         const { type, startAddress, endAddress, name } = extraData as VariableRange;
         const start = '0x' + parseInt(startAddress).toString(16);
         const end = '0x' + parseInt(endAddress || '0').toString(16);
-        const words = (startAddress && endAddress) ? parseInt(endAddress) - parseInt(startAddress) : undefined;
-        const bytes = words ? words * bytesPerWord : undefined;
+        const maus = (startAddress && endAddress) ? parseInt(endAddress) - parseInt(startAddress) : undefined;
+        const bytes = maus ? maus * bytesPerMau : undefined;
 
         const hoverItem = (
             <table className='variable-hover'>
                 <caption className='variable-hover-name'>{name}</caption>
-                {Object.entries({ type, start, end, words, bytes }).map(([label, value]) =>
+                {Object.entries({ type, start, end, MAUs: maus, bytes }).map(([label, value]) =>
                     value
                         ? <tr className='label-value-pair'>
                             <td className={`label ${label}`}>{label}</td>

--- a/src/webview/memory-webview-view.tsx
+++ b/src/webview/memory-webview-view.tsx
@@ -72,8 +72,8 @@ const DEFAULT_SESSION_CONTEXT: SessionContext = {
 };
 
 const MEMORY_DISPLAY_CONFIGURATION_DEFAULTS: MemoryDisplayConfiguration = {
-    bytesPerWord: 1,
-    wordsPerGroup: 1,
+    bytesPerMau: 1,
+    mausPerGroup: 1,
     groupsPerRow: 4,
     endianness: Endianness.Little,
     scrollingBehavior: 'Paginate',
@@ -163,7 +163,7 @@ class App extends React.Component<{}, MemoryAppState> {
         try {
             // If we are dealing with numeric addresses (and not expressions) then we can determine the overlap.
             // Note that we use big int arithmetic here to determine the overlap for (start address + length) vs (memory state address + length), i.e.,
-            // we do not actually determine the end address may need to consider the size of a word in bytes
+            // we do not actually determine the end address may need to consider the size of a MAU in bytes
             const written: BigIntMemoryRange = {
                 startAddress: BigInt(writtenMemory.memoryReference),
                 endAddress: BigInt(writtenMemory.memoryReference) + BigInt(writtenMemory.count ?? 0)
@@ -212,10 +212,10 @@ class App extends React.Component<{}, MemoryAppState> {
                 isFrozen={this.state.isFrozen}
                 fetchMemory={this.fetchMemory}
                 isMemoryFetching={this.state.isMemoryFetching}
-                bytesPerWord={this.state.bytesPerWord}
+                bytesPerMau={this.state.bytesPerMau}
                 groupsPerRow={this.state.groupsPerRow}
                 endianness={this.state.endianness}
-                wordsPerGroup={this.state.wordsPerGroup}
+                mausPerGroup={this.state.mausPerGroup}
                 scrollingBehavior={this.state.scrollingBehavior}
                 addressPadding={this.state.addressPadding}
                 addressRadix={this.state.addressRadix}
@@ -300,7 +300,7 @@ class App extends React.Component<{}, MemoryAppState> {
         if (memory === undefined || this.state.groupsPerRow === 'Autofit') {
             return 0;
         }
-        const rowLength = this.state.bytesPerWord * this.state.wordsPerGroup * this.state.groupsPerRow;
+        const rowLength = this.state.bytesPerMau * this.state.mausPerGroup * this.state.groupsPerRow;
         const rows = Math.ceil(memory.bytes.length / rowLength);
         const finalAddress = memory.address + BigInt(((rows - 1) * rowLength));
         return getAddressString(finalAddress, this.state.addressRadix).length;

--- a/src/webview/utils/view-types.ts
+++ b/src/webview/utils/view-types.ts
@@ -81,8 +81,8 @@ export interface MemoryViewSettings extends ColumnVisibilityStatus, MemoryDispla
 
 /** The memory display configuration that can be specified for the memory widget. */
 export interface MemoryDisplayConfiguration {
-    bytesPerWord: number;
-    wordsPerGroup: number;
+    bytesPerMau: number;
+    mausPerGroup: number;
     groupsPerRow: GroupsPerRowOption;
     endianness: Endianness;
     scrollingBehavior: ScrollingBehavior;


### PR DESCRIPTION
#### What it does
Renames the term *word* to *MAU* as discussed in #100 for the user-facing UI and in the code. In the options widget we also added a link to the soon-to-be existing documentation contributed in #109 and add hovers above the use of the term *MAU*.

#### How to test
As this touches several files, we should make sure the functionality isn't impacted at all.
Also it makes sense to do another search for the term *word* and make sure we caught all occurrences.

#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
