### PR TITLE
Use 'evaluateName' when evaluating variables

### DIFF
--- a/src/plugin/adapter-registry/c-tracker.ts
+++ b/src/plugin/adapter-registry/c-tracker.ts
@@ -44,9 +44,10 @@ export class CTracker extends AdapterVariableTracker {
         let variableAddress = extractAddress(variable.memoryReference);
         let variableSize: bigint | undefined = undefined;
         try {
+            const evaluateName = variable.evaluateName ?? variable.name;
             [variableAddress, variableSize] = await Promise.all([
-                variableAddress ?? this.getAddressOfVariable(variable.name, session),
-                this.getSizeOfVariable(variable.name, session)
+                variableAddress ?? this.getAddressOfVariable(evaluateName, session),
+                this.getSizeOfVariable(evaluateName, session)
             ]);
         } catch (err) {
             this.logger.warn('Unable to resolve location and size of', variable.name + (err instanceof Error ? ':\n\t' + err.message : ''));


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/blob/main/CONTRIBUTING.md
-->

#### What it does
If available, use 'evaluateName' instead of 'name' for evaluatable expressions. As far as I could find, this is the only place where variable names are evaluated.

Closes #120.

#### How to test
Start any debugger that provides an `evaluateName` (such as cppdbg) and make sure the variables column displays ranges correctly.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the contribution guidelines](https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/blob/main/CONTRIBUTING.md)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the code of conduct](https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/blob/main/CODE_OF_CONDUCT.md)
