### PR TITLE
Follow pointers

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,8 +86,8 @@
         "category": "Memory"
       },
       {
-        "command": "memory-inspector.follow-pointer",
-        "title": "Follow Pointer",
+        "command": "memory-inspector.go-to-address-value",
+        "title": "Go to value in Memory Inspector",
         "category": "Memory"
       },
       {
@@ -150,6 +150,10 @@
           "when": "canViewMemory && memory-inspector.canRead"
         },
         {
+          "command": "memory-inspector.go-to-address-value",
+          "when": "canViewMemory && memory-inspector.canRead && memory-inspector.variable.isPointer"
+        },
+        {
           "command": "memory-inspector.store-file",
           "when": "canViewMemory && memory-inspector.canRead"
         }
@@ -206,7 +210,7 @@
           "when": "webviewId === memory-inspector.memory"
         },
         {
-          "command": "memory-inspector.follow-pointer",
+          "command": "memory-inspector.go-to-address-value",
           "group": "display@7",
           "when": "webviewId === memory-inspector.memory && memory-inspector.variable.isPointer"
         }

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
         "category": "Memory"
       },
       {
-        "command": "memory-inspector.go-to-address-value",
+        "command": "memory-inspector.go-to-value",
         "title": "Go to value in Memory Inspector",
         "category": "Memory"
       },
@@ -150,7 +150,7 @@
           "when": "canViewMemory && memory-inspector.canRead"
         },
         {
-          "command": "memory-inspector.go-to-address-value",
+          "command": "memory-inspector.go-to-value",
           "when": "canViewMemory && memory-inspector.canRead && memory-inspector.variable.isPointer"
         },
         {
@@ -210,7 +210,7 @@
           "when": "webviewId === memory-inspector.memory"
         },
         {
-          "command": "memory-inspector.go-to-address-value",
+          "command": "memory-inspector.go-to-value",
           "group": "display@7",
           "when": "webviewId === memory-inspector.memory && memory-inspector.variable.isPointer"
         }

--- a/package.json
+++ b/package.json
@@ -86,6 +86,11 @@
         "category": "Memory"
       },
       {
+        "command": "memory-inspector.follow-pointer",
+        "title": "Follow Pointer",
+        "category": "Memory"
+      },
+      {
         "command": "memory-inspector.toggle-variables-column",
         "title": "Toggle Variables Column",
         "category": "Memory",
@@ -199,6 +204,11 @@
           "command": "memory-inspector.apply-file",
           "group": "display@6",
           "when": "webviewId === memory-inspector.memory"
+        },
+        {
+          "command": "memory-inspector.follow-pointer",
+          "group": "display@7",
+          "when": "webviewId === memory-inspector.memory && memory-inspector.variable.isPointer"
         }
       ]
     },

--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
       "debug/variables/context": [
         {
           "command": "memory-inspector.show-variable",
-          "when": "memory-inspector.canRead"
+          "when": "canViewMemory && memory-inspector.canRead"
         },
         {
           "command": "memory-inspector.store-file",

--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
       "debug/variables/context": [
         {
           "command": "memory-inspector.show-variable",
-          "when": "canViewMemory && memory-inspector.canRead"
+          "when": "memory-inspector.canRead"
         },
         {
           "command": "memory-inspector.store-file",

--- a/src/common/debug-requests.ts
+++ b/src/common/debug-requests.ts
@@ -29,7 +29,8 @@ export interface DebugRequestTypes {
 
 export interface DebugEvents {
     'memory': DebugProtocol.MemoryEvent,
-    'stopped': DebugProtocol.StoppedEvent
+    'stopped': DebugProtocol.StoppedEvent,
+    'output': DebugProtocol.OutputEvent,
 }
 
 export type DebugRequest<C, A> = Omit<DebugProtocol.Request, 'command' | 'arguments'> & { command: C, arguments: A };

--- a/src/common/memory-range.ts
+++ b/src/common/memory-range.ts
@@ -108,6 +108,7 @@ export interface VariableMetadata {
     type?: string;
     /** If applicable, a string representation of the variable's value */
     value?: string;
+    isPointer?: boolean;
 }
 
 /** Suitable for transmission as JSON */

--- a/src/common/webview-context.ts
+++ b/src/common/webview-context.ts
@@ -58,3 +58,13 @@ export function isWebviewContext(args: WebviewContext | unknown): args is Webvie
         && typeof assumed.showRadixPrefix === 'boolean' && typeof assumed.activeReadArguments?.count === 'number' && typeof assumed.activeReadArguments?.offset === 'number'
         && typeof assumed.activeReadArguments?.memoryReference === 'string';
 }
+
+export function isWebviewVariableContext(args: WebviewVariableContext | unknown): args is Required<WebviewVariableContext> {
+    const assumed = args ? args as WebviewVariableContext : undefined;
+    return !!assumed && isWebviewContext(args)
+        && !!assumed.variable
+        && typeof assumed.variable.name === 'string' && !!assumed.variable.name
+        && (typeof assumed.variable.type === 'string' || assumed.variable.type === undefined)
+        && (typeof assumed.variable.value === 'string' || assumed.variable.value === undefined)
+        && (typeof assumed.variable.isPointer === 'boolean' || assumed.variable.isPointer === undefined);
+}

--- a/src/plugin/adapter-registry/c-tracker.ts
+++ b/src/plugin/adapter-registry/c-tracker.ts
@@ -64,6 +64,7 @@ export class CTracker extends AdapterVariableTracker {
             endAddress: variableSize === undefined ? undefined : toHexStringWithRadixMarker(address + variableSize),
             value: variable.value,
             type: variable.type,
+            isPointer: this.isPointer(variable),
         };
         return variableRange;
     }
@@ -76,5 +77,9 @@ export class CTracker extends AdapterVariableTracker {
     async getSizeOfVariable(variableName: string, session: vscode.DebugSession): Promise<bigint | undefined> {
         const response = await sendRequest(session, 'evaluate', { expression: CEvaluateExpression.sizeOf(variableName), context: 'watch', frameId: this.currentFrame });
         return notADigit.test(response.result) ? undefined : BigInt(response.result);
+    }
+
+    protected isPointer(variable: DebugProtocol.Variable): boolean {
+        return (!variable.type || variable.type.endsWith('*')) && (`0x${Number(variable.value).toString(16)}` === variable.value);
     }
 }

--- a/src/plugin/memory-webview-main.ts
+++ b/src/plugin/memory-webview-main.ts
@@ -65,7 +65,7 @@ export class MemoryWebview implements vscode.CustomReadonlyEditorProvider {
     public static ViewType = `${manifest.PACKAGE_NAME}.memory`;
     public static ShowCommandType = `${manifest.PACKAGE_NAME}.show`;
     public static VariableCommandType = `${manifest.PACKAGE_NAME}.show-variable`;
-    public static GoToAddressValueCommandType = `${manifest.PACKAGE_NAME}.go-to-address-value`;
+    public static GoToValueCommandType = `${manifest.PACKAGE_NAME}.go-to-value`;
     public static ToggleAsciiColumnCommandType = `${manifest.PACKAGE_NAME}.toggle-ascii-column`;
     public static ToggleVariablesColumnCommandType = `${manifest.PACKAGE_NAME}.toggle-variables-column`;
     public static ToggleRadixPrefixCommandType = `${manifest.PACKAGE_NAME}.toggle-radix-prefix`;
@@ -98,7 +98,7 @@ export class MemoryWebview implements vscode.CustomReadonlyEditorProvider {
                     this.show({ memoryReference });
                 }
             }),
-            vscode.commands.registerCommand(MemoryWebview.GoToAddressValueCommandType, async args => {
+            vscode.commands.registerCommand(MemoryWebview.GoToValueCommandType, async args => {
                 if (isWebviewVariableContext(args) && args.variable.isPointer) {
                     this.show({ memoryReference: args.variable.value });
                 }

--- a/src/plugin/memory-webview-main.ts
+++ b/src/plugin/memory-webview-main.ts
@@ -65,7 +65,7 @@ export class MemoryWebview implements vscode.CustomReadonlyEditorProvider {
     public static ViewType = `${manifest.PACKAGE_NAME}.memory`;
     public static ShowCommandType = `${manifest.PACKAGE_NAME}.show`;
     public static VariableCommandType = `${manifest.PACKAGE_NAME}.show-variable`;
-    public static FollowPointerCommandtype = `${manifest.PACKAGE_NAME}.follow-pointer`;
+    public static GoToAddressValueCommandType = `${manifest.PACKAGE_NAME}.go-to-address-value`;
     public static ToggleAsciiColumnCommandType = `${manifest.PACKAGE_NAME}.toggle-ascii-column`;
     public static ToggleVariablesColumnCommandType = `${manifest.PACKAGE_NAME}.toggle-variables-column`;
     public static ToggleRadixPrefixCommandType = `${manifest.PACKAGE_NAME}.toggle-radix-prefix`;
@@ -98,12 +98,9 @@ export class MemoryWebview implements vscode.CustomReadonlyEditorProvider {
                     this.show({ memoryReference });
                 }
             }),
-            vscode.commands.registerCommand(MemoryWebview.FollowPointerCommandtype, async args => {
+            vscode.commands.registerCommand(MemoryWebview.GoToAddressValueCommandType, async args => {
                 if (isWebviewVariableContext(args) && args.variable.isPointer) {
-                    const memoryReference = args.variable.value;
-                    if (memoryReference) {
-                        this.show({ memoryReference });
-                    }
+                    this.show({ memoryReference: args.variable.value });
                 }
             }),
             vscode.commands.registerCommand(MemoryWebview.ToggleVariablesColumnCommandType, (ctx: WebviewContext) => {

--- a/src/plugin/memory-webview-main.ts
+++ b/src/plugin/memory-webview-main.ts
@@ -14,6 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+import type { DebugProtocol } from '@vscode/debugprotocol';
 import * as vscode from 'vscode';
 import { Messenger } from 'vscode-messenger';
 import { WebviewIdMessageParticipant } from 'vscode-messenger-common';
@@ -93,8 +94,37 @@ export class MemoryWebview implements vscode.CustomReadonlyEditorProvider {
             vscode.commands.registerCommand(MemoryWebview.ShowCommandType, () => this.show()),
             vscode.commands.registerCommand(MemoryWebview.VariableCommandType, async args => {
                 if (isVariablesContext(args)) {
-                    const memoryReference = args.variable.memoryReference ?? await this.memoryProvider.getAddressOfVariable(args.variable.name);
-                    this.show({ memoryReference });
+                    let maybeError;
+                    /*
+                    Use the first available address from this list.
+                    1. The variable's memoryReference if it exists.
+                    2. Try to get the address for the variable name.
+                        2.1. Use the final component of the evaluateName, which handles arrays correctly (e.g. "my_char[2]")
+                        2.2. Fall back to using the simple name if there is no evaluateName
+                    3. If the container value appears to be a memory address, use that.
+                    4. Lastly, if the container has its own address, use that.
+                    */
+                    let memoryReference = args.variable.memoryReference;                            // #1
+
+                    try {
+                        memoryReference ??= await this.memoryProvider.getAddressOfVariable(
+                            args.variable.evaluateName?.split('.').pop()                            // #2.1
+                            ?? args.variable.name                                                   // #2.2
+                        );
+                    } catch (e) { maybeError = e; }
+
+                    const containerValue = (args.container as DebugProtocol.Variable).value;
+                    if (`0x${Number(containerValue).toString(16)}` === containerValue) {
+                        memoryReference ??= containerValue;                                         // #3
+                    }
+
+                    memoryReference ??= (args.container as DebugProtocol.Variable).memoryReference; // #4
+
+                    if (memoryReference) {
+                        this.show({ memoryReference });
+                    } else if (maybeError) {
+                        throw maybeError;
+                    }
                 }
             }),
             vscode.commands.registerCommand(MemoryWebview.ToggleVariablesColumnCommandType, (ctx: WebviewContext) => {

--- a/src/plugin/memory-webview-main.ts
+++ b/src/plugin/memory-webview-main.ts
@@ -44,7 +44,7 @@ import {
     WriteMemoryResult,
     writeMemoryType,
 } from '../common/messaging';
-import { getVisibleColumns, WebviewContext } from '../common/webview-context';
+import { getVisibleColumns, isWebviewVariableContext, WebviewContext } from '../common/webview-context';
 import { AddressPaddingOptions, MemoryViewSettings, ScrollingBehavior } from '../webview/utils/view-types';
 import { isVariablesContext } from './external-views';
 import { outputChannelLogger } from './logger';
@@ -66,6 +66,7 @@ export class MemoryWebview implements vscode.CustomReadonlyEditorProvider {
     public static ViewType = `${manifest.PACKAGE_NAME}.memory`;
     public static ShowCommandType = `${manifest.PACKAGE_NAME}.show`;
     public static VariableCommandType = `${manifest.PACKAGE_NAME}.show-variable`;
+    public static FollowPointerCommandtype = `${manifest.PACKAGE_NAME}.follow-pointer`;
     public static ToggleAsciiColumnCommandType = `${manifest.PACKAGE_NAME}.toggle-ascii-column`;
     public static ToggleVariablesColumnCommandType = `${manifest.PACKAGE_NAME}.toggle-variables-column`;
     public static ToggleRadixPrefixCommandType = `${manifest.PACKAGE_NAME}.toggle-radix-prefix`;
@@ -124,6 +125,14 @@ export class MemoryWebview implements vscode.CustomReadonlyEditorProvider {
                         this.show({ memoryReference });
                     } else if (maybeError) {
                         throw maybeError;
+                    }
+                }
+            }),
+            vscode.commands.registerCommand(MemoryWebview.FollowPointerCommandtype, async args => {
+                if (isWebviewVariableContext(args) && args.variable.isPointer) {
+                    const memoryReference = args.variable.value;
+                    if (memoryReference) {
+                        this.show({ memoryReference });
                     }
                 }
             }),


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/blob/main/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Closes #123.

Two closely related capabilities. In the example images, `int *ii = &i` .

1. Offer the "Show in Memory Inspector" on child elements of the tree in the debug Variables view. A common kind of child element is the reference of a pointer. Other kinds include array elements and struct members.  
![image](https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/assets/20653241/6f4d264d-000c-40d1-a818-cc0c03578bc6)
2. Provide a "Follow Pointer" context menu on pointer variables in the memory inspector Variables column.  
![image](https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/assets/20653241/302cbecb-c08e-43b5-8e39-45a269642402)

Although (1) works in all conditions I've tested so far (using C++), arguably it should be handled upstream by VSCode or `gdb` or other. VSCode's `canViewMemory` context is set according to whether a tree item has a `memoryReference` property already provided; but this property is not set on child elements of the tree even when it's readily available. However, the memory inspector already contained code to handle cases with a missing memoryReference, so in my current view, the (1) feature simply makes this more thorough.

For (2), to use webview context in a command's `when` clause, I added flattened versions of nested keys as required by VSCode. It seemed like a good choice in case other webview context is to be used similarly in the future. However, an alternative could be simply adding a top-level key, e.g. `memoryInspectorVariableIsPointer` instead of `memory-inspector.variable.isPointer`.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Right-click on child elements in the debug Variables view & choose "Show in Memory Inspector".
2. The "Follow Pointer" context menu item should show only on pointer variables in the memory inspector Variables column, and should reveal an inspector at the pointer's reference.

#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the contribution guidelines](https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/blob/main/CONTRIBUTING.md)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the code of conduct](https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/blob/main/CODE_OF_CONDUCT.md)
