### PR TITLE
Fix React warnings & use after dispose errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,9 +41,9 @@
     "primereact": "^10.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "vscode-messenger": "^0.4.3",
-    "vscode-messenger-common": "^0.4.3",
-    "vscode-messenger-webview": "^0.4.3",
+    "vscode-messenger": "^0.4.5",
+    "vscode-messenger-common": "^0.4.5",
+    "vscode-messenger-webview": "^0.4.5",
     "vscode-uri": "^3.0.8"
   },
   "devDependencies": {

--- a/src/webview/hovers/address-hover.tsx
+++ b/src/webview/hovers/address-hover.tsx
@@ -74,14 +74,16 @@ export class AddressHover implements HoverContribution {
 
         const hoverItem = (
             <table className='address-hover'>
-                {Object.entries({ binary, octal, decimal, hexadecimal, utf8 }).map(([label, value]) =>
-                    value
-                        ? <tr className={`label-value-pair ${label === primaryRadix ? 'primary' : ''}`}>
-                            <td className={`label ${label}`}>{label}</td>
-                            <td className={`value ${label}`}>{value}</td>
-                        </tr>
-                        : ''
-                )}
+                <tbody>
+                    {Object.entries({ binary, octal, decimal, hexadecimal, utf8 }).map(([label, value]) =>
+                        value
+                            ? <tr className={`label-value-pair ${label === primaryRadix ? 'primary' : ''}`} key={label}>
+                                <td className={`label ${label}`}>{label}</td>
+                                <td className={`value ${label}`}>{value}</td>
+                            </tr>
+                            : ''
+                    )}
+                </tbody>
             </table>
         );
         return hoverItem;

--- a/src/webview/hovers/data-hover.tsx
+++ b/src/webview/hovers/data-hover.tsx
@@ -36,14 +36,16 @@ export class DataHover implements HoverContribution {
 
         const hoverItem = (
             <table className='data-hover'>
-                {Object.entries({ binary, octal, decimal, hexadecimal, utf8 }).map(([label, value]) =>
-                    value
-                        ? <tr className='label-value-pair'>
-                            <td className={`label ${label}`}>{label}</td>
-                            <td className={`value ${label}`}>{value}</td>
-                        </tr>
-                        : ''
-                )}
+                <tbody>
+                    {Object.entries({ binary, octal, decimal, hexadecimal, utf8 }).map(([label, value]) =>
+                        value
+                            ? <tr className='label-value-pair' key={label}>
+                                <td className={`label ${label}`}>{label}</td>
+                                <td className={`value ${label}`}>{value}</td>
+                            </tr>
+                            : ''
+                    )}
+                </tbody>
             </table>
         );
         return hoverItem;

--- a/src/webview/hovers/hover-service.tsx
+++ b/src/webview/hovers/hover-service.tsx
@@ -73,7 +73,7 @@ export class HoverService {
             } catch (err) {
                 messenger.sendRequest(logMessageType, HOST_EXTENSION, `Error in hover contribution ${contribution.id}: ${err}`);
             }
-            return hoverPart;
+            return hoverPart && <div key={contribution.id}>{hoverPart}</div>;
         });
         const nodes = (await Promise.all(promises)).filter(node => !!node);
         if (nodes.length > 0) {

--- a/src/webview/hovers/variable-hover.tsx
+++ b/src/webview/hovers/variable-hover.tsx
@@ -36,14 +36,16 @@ export class VariableHover implements HoverContribution {
         const hoverItem = (
             <table className='variable-hover'>
                 <caption className='variable-hover-name'>{name}</caption>
-                {Object.entries({ type, start, end, MAUs: maus, bytes }).map(([label, value]) =>
-                    value
-                        ? <tr className='label-value-pair'>
-                            <td className={`label ${label}`}>{label}</td>
-                            <td className={`value ${label}`}>{value}</td>
-                        </tr>
-                        : ''
-                )}
+                <tbody>
+                    {Object.entries({ type, start, end, MAUs: maus, bytes }).map(([label, value]) =>
+                        value
+                            ? <tr className='label-value-pair' key={label}>
+                                <td className={`label ${label}`}>{label}</td>
+                                <td className={`value ${label}`}>{value}</td>
+                            </tr>
+                            : ''
+                    )}
+                </tbody>
             </table>
         );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3365,24 +3365,24 @@ vary@~1.1.2:
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==
 
-vscode-messenger-common@^0.4.3:
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/vscode-messenger-common/-/vscode-messenger-common-0.4.3.tgz#362e19eba84906c94521fab41522462b548c5f8c"
-  integrity sha512-6P7OlT7UthfMHe1IcSgv/5f7iELIAXUQ1wCQbciurJo6gwLHFAFqzg/F6TA7wJL5L1/0tyLSKMUWFa0HT/q0GA==
+vscode-messenger-common@^0.4.5:
+  version "0.4.5"
+  resolved "https://registry.yarnpkg.com/vscode-messenger-common/-/vscode-messenger-common-0.4.5.tgz#bc49a25d28808db9cc322cde029fed518c8fa382"
+  integrity sha512-opA+BEYTWdy1fFC3oOw30b0zc/KEuMtw+1pOiH5fEp+BGeA5xff7omSQTZeZJSDJszM471Vi+YY/ipRdRglAlQ==
 
-vscode-messenger-webview@^0.4.3:
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/vscode-messenger-webview/-/vscode-messenger-webview-0.4.3.tgz#80b45af2ee3df5bdef11a80042c8ab63fd8490b1"
-  integrity sha512-/gyU6tDXI/rUFPDkKY7a5al7Y8Pv4OFrnqETcR3hex6o/LjAo6R41n6xmx5J7SC1OXYMjKzqs2og/5KZ09M/gA==
+vscode-messenger-webview@^0.4.5:
+  version "0.4.5"
+  resolved "https://registry.yarnpkg.com/vscode-messenger-webview/-/vscode-messenger-webview-0.4.5.tgz#89767aee50038acb6a706f5427e0fc72d5aec7f5"
+  integrity sha512-pzGB6HoTfPszMF4HQG+u5WMJ959iGLmow6ehYVTZnZjZ+phBKEBtpTYAjJSNotyUfZJ58NCdq5+ZSvMgkAuAJw==
   dependencies:
-    vscode-messenger-common "^0.4.3"
+    vscode-messenger-common "^0.4.5"
 
-vscode-messenger@^0.4.3:
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/vscode-messenger/-/vscode-messenger-0.4.3.tgz#9e07b16ef11335a9a0c21e75a338a5623e639c78"
-  integrity sha512-zOkWT/gXVvksYjtuTfGYWhc2Kn+OFDQl7w2P/LodFufC35tGo6tko28ACSJgvrIFeIhhI11XgMhlCGcT3QZGRA==
+vscode-messenger@^0.4.5:
+  version "0.4.5"
+  resolved "https://registry.yarnpkg.com/vscode-messenger/-/vscode-messenger-0.4.5.tgz#decf7475568ce3a3912479c29ff1e6eac61c7470"
+  integrity sha512-a6e54dpPRi/ITmVex49LGU6YXlqcuxGPlDPauvZig20G1D1/QD2E8GfhtvlTj3ml5aU/QV3LHghyepq3riy7sw==
   dependencies:
-    vscode-messenger-common "^0.4.3"
+    vscode-messenger-common "^0.4.5"
 
 vscode-uri@^3.0.8:
   version "3.0.8"


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/blob/main/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

This PR fixes a number of React errors related to keys and element hierarchy that appeared in the dev console when a hover was shown.

In addition, when  webview was closed, an error would be logged related to an attempt by `vscode-messenger` to access a property on the now-disposed-of view. That has [been fixed](https://github.com/TypeFox/vscode-messenger/commit/6bebe60fffeb1706603f0a7eca2a07c8bfb26b05).

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Open up the dev tools.
2. Open a memory view and show a hover.
3. No React errors should appear in the dev tools console.
4. Close the webview.
5. No errors related to the webview being disposed should appear. Sometimes errors with the text `Invalid debug adapter` appear, but those appear to be internal to VSCode.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the contribution guidelines](https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/blob/main/CONTRIBUTING.md)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the code of conduct](https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/blob/main/CODE_OF_CONDUCT.md)
