### PR TITLE
Add separators to context menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,13 +111,13 @@
       },
       {
         "command": "memory-inspector.store-file",
-        "title": "Store Memory to File",
+        "title": "Store Memory to File...",
         "enablement": "memory-inspector.canRead",
         "category": "Memory"
       },
       {
         "command": "memory-inspector.apply-file",
-        "title": "Apply Memory from File",
+        "title": "Apply Memory from File...",
         "enablement": "memory-inspector.canWrite",
         "category": "Memory"
       }
@@ -172,32 +172,32 @@
       "webview/context": [
         {
           "command": "memory-inspector.toggle-variables-column",
-          "group": "display@1",
+          "group": "a_display@1",
           "when": "webviewId === memory-inspector.memory"
         },
         {
           "command": "memory-inspector.toggle-ascii-column",
-          "group": "display@2",
+          "group": "a_display@2",
           "when": "webviewId === memory-inspector.memory"
         },
         {
           "command": "memory-inspector.toggle-radix-prefix",
-          "group": "display@3",
-          "when": "webviewId === memory-inspector.memory"
-        },
-        {
-          "command": "memory-inspector.show-advanced-display-options",
-          "group": "display@4",
+          "group": "a_display@3",
           "when": "webviewId === memory-inspector.memory"
         },
         {
           "command": "memory-inspector.store-file",
-          "group": "display@5",
+          "group": "c_store-and-restore@1",
           "when": "webviewId === memory-inspector.memory"
         },
         {
           "command": "memory-inspector.apply-file",
-          "group": "display@6",
+          "group": "c_store-and-restore@2",
+          "when": "webviewId === memory-inspector.memory"
+        },
+        {
+          "command": "memory-inspector.show-advanced-display-options",
+          "group": "z_more",
           "when": "webviewId === memory-inspector.memory"
         }
       ]


### PR DESCRIPTION
#### What it does
The number of menu items in the memory inspector's context menu already contributes to a convoluted list. In this change we add separators grouping those that are related to each other. To be consistent with other core context menu entires, I also added `...` to those menu items, where additional input will be required.

![image](https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/assets/588090/287e235d-04d3-42ff-88f4-a8ed15a96197)

#### How to test
This change only re-groups them to realize separators, so there is nothing more to test other than the grouping matches the expectations.

#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the contribution guidelines](https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/blob/main/CONTRIBUTING.md)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the code of conduct](https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/blob/main/CODE_OF_CONDUCT.md)
