### PR TITLE
Fix a few typos

### DIFF
--- a/src/plugin/adapter-registry/adapter-capabilities.ts
+++ b/src/plugin/adapter-registry/adapter-capabilities.ts
@@ -26,7 +26,7 @@ export interface AdapterCapabilities {
     getVariables?(session: vscode.DebugSession): Promise<VariableRange[]>;
     /** Resolve symbols resident in the memory at the specified range. Will be preferred to {@link getVariables} if present. */
     getResidents?(session: vscode.DebugSession, params: DebugProtocol.ReadMemoryArguments): Promise<VariableRange[]>;
-    /** Resolves the address of a given variable in bytes withthe current context. */
+    /** Resolves the address of a given variable in bytes with the current context. */
     getAddressOfVariable?(session: vscode.DebugSession, variableName: string): Promise<string | undefined>;
     /** Resolves the size of a given variable in bytes within the current context. */
     getSizeOfVariable?(session: vscode.DebugSession, variableName: string): Promise<bigint | undefined>;
@@ -48,7 +48,7 @@ export function extractDecimalAddress(text?: string): string | undefined {
 }
 
 export function extractAddress(text?: string): string | undefined {
-    // search for hex address first as a hex adress (0x12345678) also matches an integer address (12345678)
+    // search for hex address first as a hex address (0x12345678) also matches an integer address (12345678)
     return text ? extractHexAddress(text) ?? extractDecimalAddress(text) : undefined;
 }
 

--- a/src/plugin/memory-provider.ts
+++ b/src/plugin/memory-provider.ts
@@ -122,17 +122,17 @@ export class MemoryProvider {
     /** Returns the session if the capability is present, otherwise throws. */
     protected assertCapability(capability: keyof DebugProtocol.Capabilities, action: string): vscode.DebugSession {
         const session = this.assertActiveSession(action);
-        if (!this.hasDebugCapabilitiy(session, capability)) {
+        if (!this.hasDebugCapability(session, capability)) {
             throw new Error(`Cannot ${action}. Session does not have capability ${capability}.`);
         }
         return session;
     }
 
-    protected hasDebugCapabilitiy(session: vscode.DebugSession, capability: keyof DebugProtocol.Capabilities): boolean {
+    protected hasDebugCapability(session: vscode.DebugSession, capability: keyof DebugProtocol.Capabilities): boolean {
         return !!this.sessionDebugCapabilities.get(session.id)?.[capability];
     }
 
-    protected hasClientCapabilitiy(session: vscode.DebugSession, capability: keyof DebugProtocol.InitializeRequestArguments): boolean {
+    protected hasClientCapability(session: vscode.DebugSession, capability: keyof DebugProtocol.InitializeRequestArguments): boolean {
         return !!this.sessionClientCapabilities.get(session.id)?.[capability];
     }
 

--- a/src/webview/columns/column-contribution-service.ts
+++ b/src/webview/columns/column-contribution-service.ts
@@ -28,7 +28,7 @@ export interface ColumnContribution {
     readonly label: string;
     /** Depending on the supported fitting mode, the column will be rendered differently */
     fittingType?: ColumnFittingType;
-    /** Sorted low to high. If ommitted, sorted alphabetically by ID after all contributions with numbers. */
+    /** Sorted low to high. If omitted, sorted alphabetically by ID after all contributions with numbers. */
     priority?: number;
     render(range: BigIntMemoryRange, memory: Memory, options: TableRenderOptions): React.ReactNode
     /** Called when fetching new memory or when activating the column. */
@@ -54,7 +54,7 @@ class ColumnContributionService {
     protected columnArray = new Array<ColumnStatus>();
     protected registeredColumns = new Map<string, ColumnStatus>;
     /**
-     * @param configurable - if `false`, the column will always be dispayled.
+     * @param configurable - if `false`, the column will always be displayed.
      * @param defaultActive if {@link configurable} is `false`, this field will default to `true` and be ignored. Otherwise defaults to `false`.
      */
     register(contribution: ColumnContribution, configurable = true, defaultActive?: boolean): Disposable {


### PR DESCRIPTION
#### What it does
This change just fixes a few typos that I came across while working on other tasks.

#### How to test
The only code-relevant changes are in the names of protected methods in the `MemoryProvider` class. Unless someone subclassed this class in proprietary code, there isn't really anything this change could break.

#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the contribution guidelines](https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/blob/main/CONTRIBUTING.md)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the code of conduct](https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/blob/main/CODE_OF_CONDUCT.md)
