### PR TITLE
Enable extenders to overwrite default settings

### DIFF
--- a/media/options-widget.css
+++ b/media/options-widget.css
@@ -98,19 +98,61 @@
   color: var(--vscode-descriptionForeground);
 }
 
-.advanced-options-content {
-  color: var(--vscode-settings-headerForeground);
+.advanced-options-panel .p-overlaypanel-content {
+  padding: 0.8rem;
 }
 
-.advanced-options-content h2 {
-  font-size: 110%;
-  margin: 1.2rem 0 0 0;
+.advanced-options-panel .advanced-options-header {
+  font-size: 11px;
+  text-transform: uppercase;
+  line-height: 22px;
+  margin:0;
+  font-weight: normal;
+}
+
+.advanced-options-accordion a:focus {
+  outline-color: var(--vscode-focusBorder);
+}
+
+.advanced-options-accordion .p-accordion-tab {
+  width: 180px;
+}
+
+.advanced-options-accordion .p-accordion-header {
+  border-top: 1px solid var(--vscode-widget-border);
+  color: var(--vscode-sideBarSectionHeader-foreground);
+}
+
+.advanced-options-accordion .p-accordion-header-link {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: var(--vscode-sideBarSectionHeader-foreground);
+}
+
+.advanced-options-accordion .p-accordion-header-text {
+  font-size: 11px;
+  text-transform: uppercase;
+  font-weight: bold;
+  line-height: 22px;
+}
+
+.advanced-options-accordion .p-accordion-toggle-icon {
+  margin-right: 3px;
+}
+
+.advanced-options-content {
+  color: var(--vscode-settings-headerForeground);
+  padding-bottom: 0.5rem;
 }
 
 .advanced-options-toggle {
   margin-left: auto;
   align-self: start;
   margin-top: 1.1rem
+}
+
+.p-accordion-content .advanced-options-content {
+  padding-left: 0.5rem;
 }
 
 .advanced-options-content {
@@ -143,6 +185,7 @@
   overflow-y: scroll;
   max-height: 100%;
   margin-top: 0px;
+  width: 210px;
 }
 .advanced-options-panel::-webkit-scrollbar-track {
   background-color: var(--vscode-dropdown-listBackground);

--- a/media/options-widget.css
+++ b/media/options-widget.css
@@ -172,7 +172,7 @@
   margin: 0.5rem 0 0.2rem 0;
 }
 
-.reset-advanced-options-icon {
+.more-actions-overlay-icon {
   position: absolute;
   top: 12px;
   right: 0;
@@ -203,4 +203,10 @@
 .option-help-icon {
   color: var(--vscode-button-background);
   margin-left: 0.2em;
+}
+
+.settings-contribution-message {
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+  color: var(--vscode-descriptionForeground);
 }

--- a/package.json
+++ b/package.json
@@ -126,6 +126,18 @@
         "title": "Apply Memory from File...",
         "enablement": "memory-inspector.canWrite",
         "category": "Memory"
+      },
+      {
+        "command": "memory-inspector.reset-display-options-to-debugger-defaults",
+        "title": "Reset to Debugger Defaults",
+        "enablement": "optionsMenu && hasDebuggerDefaults",
+        "category": "Memory"
+      },
+      {
+        "command": "memory-inspector.reset-display-options",
+        "title": "Reset to Defaults",
+        "enablement": "optionsMenu",
+        "category": "Memory"
       }
     ],
     "menus": {
@@ -183,37 +195,47 @@
         {
           "command": "memory-inspector.toggle-variables-column",
           "group": "a_display@1",
-          "when": "webviewId === memory-inspector.memory"
+          "when": "webviewId === memory-inspector.memory && !optionsMenu"
         },
         {
           "command": "memory-inspector.toggle-ascii-column",
           "group": "a_display@2",
-          "when": "webviewId === memory-inspector.memory"
+          "when": "webviewId === memory-inspector.memory && !optionsMenu"
         },
         {
           "command": "memory-inspector.toggle-radix-prefix",
           "group": "a_display@3",
-          "when": "webviewId === memory-inspector.memory"
+          "when": "webviewId === memory-inspector.memory && !optionsMenu"
         },
         {
           "command": "memory-inspector.store-file",
           "group": "c_store-and-restore@1",
-          "when": "webviewId === memory-inspector.memory"
+          "when": "webviewId === memory-inspector.memory && !optionsMenu"
         },
         {
           "command": "memory-inspector.apply-file",
           "group": "c_store-and-restore@2",
-          "when": "webviewId === memory-inspector.memory"
+          "when": "webviewId === memory-inspector.memory && !optionsMenu"
         },
         {
           "command": "memory-inspector.show-advanced-display-options",
           "group": "z_more",
-          "when": "webviewId === memory-inspector.memory"
+          "when": "webviewId === memory-inspector.memory && !optionsMenu"
         },
         {
           "command": "memory-inspector.go-to-value",
           "group": "display@7",
-          "when": "webviewId === memory-inspector.memory && memory-inspector.variable.isPointer"
+          "when": "webviewId === memory-inspector.memory && memory-inspector.variable.isPointer && !optionsMenu"
+        },
+        {
+          "command": "memory-inspector.reset-display-options-to-debugger-defaults",
+          "group": "a_reset@1",
+          "when": "webviewId === memory-inspector.memory && optionsMenu && hasDebuggerDefaults"
+        },
+        {
+          "command": "memory-inspector.reset-display-options",
+          "group": "a_reset@2",
+          "when": "webviewId === memory-inspector.memory && optionsMenu"
         }
       ]
     },
@@ -407,6 +429,11 @@
           "type": "boolean",
           "default": true,
           "description": "Display the radix prefix (e.g., '0x' for hexadecimal, '0b' for binary) before memory addresses."
+        },
+        "memory-inspector.allowDebuggerOverwriteSettings": {
+          "type": "boolean",
+          "default": true,
+          "description": "Allow debuggers to overwrite the default memory display settings."
         }
       }
     }

--- a/src/common/manifest.ts
+++ b/src/common/manifest.ts
@@ -74,5 +74,9 @@ export const CONFIG_SHOW_RADIX_PREFIX = 'showRadixPrefix';
 export const DEFAULT_SHOW_RADIX_PREFIX = true;
 
 // Columns
-export const CONFIG_SHOW_VARIABLES_COLUMN = 'columns.variables';
-export const CONFIG_SHOW_ASCII_COLUMN = 'columns.ascii';
+export const CONFIG_SHOW_VARIABLES_COLUMN = 'variables';
+export const CONFIG_SHOW_ASCII_COLUMN = 'ascii';
+export const DEFAULT_VISIBLE_COLUMNS = [CONFIG_SHOW_VARIABLES_COLUMN, CONFIG_SHOW_ASCII_COLUMN];
+
+// Extension Settings
+export const CONFIG_ALLOW_DEBUGGER_OVERWRITE_SETTINGS = 'allowDebuggerOverwriteSettings';

--- a/src/common/messaging.ts
+++ b/src/common/messaging.ts
@@ -48,7 +48,6 @@ export interface SessionContext {
 // Notifications
 export const readyType: NotificationType<void> = { method: 'ready' };
 export const setMemoryViewSettingsType: NotificationType<Partial<MemoryViewSettings>> = { method: 'setMemoryViewSettings' };
-export const resetMemoryViewSettingsType: NotificationType<void> = { method: 'resetMemoryViewSettings' };
 export const setTitleType: NotificationType<string> = { method: 'setTitle' };
 export const memoryWrittenType: NotificationType<WrittenMemory> = { method: 'memoryWritten' };
 export const sessionContextChangedType: NotificationType<SessionContext> = { method: 'sessionContextChanged' };

--- a/src/common/webview-configuration.ts
+++ b/src/common/webview-configuration.ts
@@ -17,16 +17,22 @@ import { WebviewIdMessageParticipant } from 'vscode-messenger-common';
 import { Endianness, GroupsPerRowOption, PeriodicRefresh, RefreshOnStop } from './manifest';
 import { Radix } from './memory-range';
 
-/** The memory display configuration that can be specified for the memory widget. */
-export interface MemoryDisplayConfiguration {
+/** Specifies the settings for displaying memory addresses in the memory data table. */
+export interface MemoryAddressDisplaySettings {
+    addressPadding: AddressPadding;
+    addressRadix: Radix;
+    showRadixPrefix: boolean;
+}
+
+export type AddressPadding = 'Min' | 0 | 32 | 64;
+
+/** Specifies the settings for displaying memory data in the memory data table, including the memory addresses. */
+export interface MemoryDataDisplaySettings extends MemoryAddressDisplaySettings {
     bytesPerMau: number;
     mausPerGroup: number;
     groupsPerRow: GroupsPerRowOption;
     endianness: Endianness;
     scrollingBehavior: ScrollingBehavior;
-    addressPadding: AddressPadding;
-    addressRadix: Radix;
-    showRadixPrefix: boolean;
     refreshOnStop: RefreshOnStop;
     periodicRefresh: PeriodicRefresh;
     periodicRefreshInterval: number;
@@ -34,14 +40,21 @@ export interface MemoryDisplayConfiguration {
 
 export type ScrollingBehavior = 'Paginate' | 'Grow' | 'Auto-Append';
 
-export type AddressPadding = 'Minimal' | number;
-
-export interface ColumnVisibilityStatus {
+/** Specifies the display settings of the memory data table, including the memory data and addresses. */
+export interface MemoryDisplaySettings extends MemoryDataDisplaySettings {
     visibleColumns: string[];
 }
 
+/** An extender's contribution to the `MemoryDisplaySettings` via the `AdapterCapabilities`. */
+export interface MemoryDisplaySettingsContribution {
+    message?: string;
+    settings?: Partial<MemoryDisplaySettings>;
+}
+
 /** All settings related to memory view that can be specified for the webview from the extension "main". */
-export interface MemoryViewSettings extends ColumnVisibilityStatus, MemoryDisplayConfiguration {
+export interface MemoryViewSettings extends MemoryDisplaySettings {
     title: string
     messageParticipant: WebviewIdMessageParticipant;
+    hasDebuggerDefaults?: boolean;
+    contributionMessage?: string;
 }

--- a/src/common/webview-context.ts
+++ b/src/common/webview-context.ts
@@ -15,6 +15,7 @@
  ********************************************************************************/
 
 import { WebviewIdMessageParticipant } from 'vscode-messenger-common';
+import * as manifest from '../common/manifest';
 import { Endianness } from './manifest';
 import { VariableMetadata } from './memory-range';
 import { ReadMemoryArguments } from './messaging';
@@ -25,6 +26,7 @@ export interface WebviewContext {
     showAsciiColumn: boolean
     showVariablesColumn: boolean,
     showRadixPrefix: boolean,
+    hasDebuggerDefaults?: boolean,
     endianness: Endianness,
     bytesPerMau: number,
     activeReadArguments: Required<ReadMemoryArguments>
@@ -46,10 +48,10 @@ export interface WebviewVariableContext extends WebviewCellContext {
 export function getVisibleColumns(context: WebviewContext): string[] {
     const columns = [];
     if (context.showAsciiColumn) {
-        columns.push('ascii');
+        columns.push(manifest.CONFIG_SHOW_ASCII_COLUMN);
     }
     if (context.showVariablesColumn) {
-        columns.push('variables');
+        columns.push(manifest.CONFIG_SHOW_VARIABLES_COLUMN);
     }
     return columns;
 }

--- a/src/plugin/adapter-registry/adapter-capabilities.ts
+++ b/src/plugin/adapter-registry/adapter-capabilities.ts
@@ -31,7 +31,7 @@ export interface AdapterCapabilities {
     getAddressOfVariable?(session: vscode.DebugSession, variableName: string): Promise<string | undefined>;
     /** Resolves the size of a given variable in bytes within the current context. */
     getSizeOfVariable?(session: vscode.DebugSession, variableName: string): Promise<bigint | undefined>;
-    /** Retrieve the enforced default display settings for the memory view. */
+    /** Retrieve the suggested default display settings for the memory view. */
     getMemoryDisplaySettings?(session: vscode.DebugSession): Promise<Partial<MemoryDisplaySettingsContribution>>;
     /** Initialize the trackers of this adapter's for the debug session. */
     initializeAdapterTracker?(session: vscode.DebugSession): vscode.DebugAdapterTracker | undefined;

--- a/src/plugin/adapter-registry/adapter-capabilities.ts
+++ b/src/plugin/adapter-registry/adapter-capabilities.ts
@@ -18,6 +18,7 @@ import { DebugProtocol } from '@vscode/debugprotocol';
 import * as vscode from 'vscode';
 import { isDebugRequest, isDebugResponse } from '../../common/debug-requests';
 import { VariableRange } from '../../common/memory-range';
+import { MemoryDisplaySettingsContribution } from '../../common/webview-configuration';
 import { Logger } from '../logger';
 
 /** Represents capabilities that may be achieved with particular debug adapters but are not part of the DAP */
@@ -30,6 +31,9 @@ export interface AdapterCapabilities {
     getAddressOfVariable?(session: vscode.DebugSession, variableName: string): Promise<string | undefined>;
     /** Resolves the size of a given variable in bytes within the current context. */
     getSizeOfVariable?(session: vscode.DebugSession, variableName: string): Promise<bigint | undefined>;
+    /** Retrieve the enforced default display settings for the memory view. */
+    getMemoryDisplaySettings?(session: vscode.DebugSession): Promise<Partial<MemoryDisplaySettingsContribution>>;
+    /** Initialize the trackers of this adapter's for the debug session. */
     initializeAdapterTracker?(session: vscode.DebugSession): vscode.DebugAdapterTracker | undefined;
 }
 

--- a/src/plugin/memory-provider.ts
+++ b/src/plugin/memory-provider.ts
@@ -20,6 +20,7 @@ import { sendRequest } from '../common/debug-requests';
 import { stringToBytesMemory } from '../common/memory';
 import { VariableRange } from '../common/memory-range';
 import { ReadMemoryResult, WriteMemoryResult } from '../common/messaging';
+import { MemoryDisplaySettingsContribution } from '../common/webview-configuration';
 import { AdapterRegistry } from './adapter-registry/adapter-registry';
 import { isSessionEvent, SessionTracker } from './session-tracker';
 
@@ -84,8 +85,14 @@ export class MemoryProvider {
     }
 
     public async getSizeOfVariable(variableName: string): Promise<bigint | undefined> {
-        const session = this.sessionTracker.assertActiveSession('get address of variable');
+        const session = this.sessionTracker.assertActiveSession('get size of variable');
         const handler = this.adapterRegistry?.getHandlerForSession(session.type);
         return handler?.getSizeOfVariable?.(session, variableName);
+    }
+
+    public async getMemoryDisplaySettingsContribution(): Promise<MemoryDisplaySettingsContribution> {
+        const session = this.sessionTracker.assertActiveSession('get memory display settings contribution');
+        const handler = this.adapterRegistry?.getHandlerForSession(session.type);
+        return handler?.getMemoryDisplaySettings?.(session) ?? {};
     }
 }

--- a/src/webview/columns/ascii-column.ts
+++ b/src/webview/columns/ascii-column.ts
@@ -15,6 +15,7 @@
  ********************************************************************************/
 
 import { ReactNode } from 'react';
+import * as manifest from '../../common/manifest';
 import { Memory } from '../../common/memory';
 import { BigIntMemoryRange, toOffset } from '../../common/memory-range';
 import { ColumnContribution, TableRenderOptions } from './column-contribution-service';
@@ -29,7 +30,7 @@ function getASCIIForSingleByte(byte: number | undefined): string {
 }
 
 export class AsciiColumn implements ColumnContribution {
-    readonly id = 'ascii';
+    readonly id = manifest.CONFIG_SHOW_ASCII_COLUMN;
     readonly label = 'ASCII';
     readonly priority = 3;
     render(range: BigIntMemoryRange, memory: Memory, options: TableRenderOptions): ReactNode {

--- a/src/webview/components/memory-table.tsx
+++ b/src/webview/components/memory-table.tsx
@@ -25,10 +25,9 @@ import { TooltipEvent } from 'primereact/tooltip/tooltipoptions';
 import { classNames } from 'primereact/utils';
 import React from 'react';
 import { Memory } from '../../common/memory';
-import { WebviewSelection } from '../../common/messaging';
-import { MemoryOptions, ReadMemoryArguments } from '../../common/messaging';
+import { MemoryOptions, ReadMemoryArguments, WebviewSelection } from '../../common/messaging';
 import { tryToNumber } from '../../common/typescript';
-import { MemoryDisplayConfiguration, ScrollingBehavior } from '../../common/webview-configuration';
+import { MemoryDataDisplaySettings, ScrollingBehavior } from '../../common/webview-configuration';
 import { TableRenderOptions } from '../columns/column-contribution-service';
 import { DataColumn } from '../columns/data-column';
 import type { HoverService } from '../hovers/hover-service';
@@ -129,7 +128,7 @@ export const MoreMemorySelect: React.FC<MoreMemoryAboveSelectProps | MoreMemoryB
     );
 };
 
-interface MemoryTableProps extends TableRenderOptions, MemoryDisplayConfiguration {
+interface MemoryTableProps extends TableRenderOptions, MemoryDataDisplaySettings {
     configuredReadArguments: Required<ReadMemoryArguments>;
     activeReadArguments: Required<ReadMemoryArguments>;
     memory?: Memory;
@@ -244,11 +243,18 @@ export class MemoryTable extends React.PureComponent<MemoryTableProps, MemoryTab
             this.setState(prev => ({ ...prev, selection: null }));
         }
 
-        const hasDisplayChanged = prevProps.bytesPerMau !== this.props.bytesPerMau || prevProps.mausPerGroup !== this.props.mausPerGroup ||
-            (prevProps.groupsPerRow !== 'Autofit' && this.props.groupsPerRow === 'Autofit');
+        // update the groups per row to render if the display options that impact the available width may have changed or we didn't have a memory before
+        const hasDisplayChanged = prevProps.bytesPerMau !== this.props.bytesPerMau
+            || prevProps.mausPerGroup !== this.props.mausPerGroup
+            || (prevProps.groupsPerRow !== 'Autofit' && this.props.groupsPerRow === 'Autofit')
+            || prevProps.columnOptions !== this.props.columnOptions
+            || prevProps.effectiveAddressLength !== this.props.effectiveAddressLength
+            || prevProps.showRadixPrefix !== this.props.showRadixPrefix
+            || prevProps.memory === undefined;
         if (hasDisplayChanged) {
             this.ensureGroupsPerRowToRenderIsSet();
         }
+
         if (this.props.memory !== undefined && this.props.scrollingBehavior === 'Auto-Append') {
             this.ensureSufficientVisibleRowsForScrollbar();
 

--- a/src/webview/components/memory-widget.tsx
+++ b/src/webview/components/memory-widget.tsx
@@ -16,10 +16,11 @@
 
 import React from 'react';
 import { WebviewIdMessageParticipant } from 'vscode-messenger-common';
+import * as manifest from '../../common/manifest';
 import { Memory } from '../../common/memory';
 import { WebviewSelection } from '../../common/messaging';
 import { MemoryOptions, ReadMemoryArguments, SessionContext } from '../../common/messaging';
-import { MemoryDisplayConfiguration } from '../../common/webview-configuration';
+import { MemoryDataDisplaySettings } from '../../common/webview-configuration';
 import { ColumnStatus } from '../columns/column-contribution-service';
 import { HoverService } from '../hovers/hover-service';
 import { Decoration, MemoryState } from '../utils/view-types';
@@ -27,7 +28,7 @@ import { createAppVscodeContext, VscodeContext } from '../utils/vscode-contexts'
 import { MemoryTable } from './memory-table';
 import { OptionsWidget } from './options-widget';
 
-interface MemoryWidgetProps extends MemoryDisplayConfiguration {
+interface MemoryWidgetProps extends MemoryDataDisplaySettings {
     messageParticipant: WebviewIdMessageParticipant;
     sessionContext: SessionContext;
     configuredReadArguments: Required<ReadMemoryArguments>;
@@ -39,12 +40,13 @@ interface MemoryWidgetProps extends MemoryDisplayConfiguration {
     columns: ColumnStatus[];
     effectiveAddressLength: number;
     isMemoryFetching: boolean;
+    hasDebuggerDefaults?: boolean;
+    settingsContributionMessage?: string;
     updateMemoryState: (state: Partial<MemoryState>) => void;
     toggleColumn(id: string, active: boolean): void;
     isFrozen: boolean;
     toggleFrozen: () => void;
-    updateMemoryDisplayConfiguration: (memoryArguments: Partial<MemoryDisplayConfiguration>) => void;
-    resetMemoryDisplayConfiguration: () => void;
+    updateMemoryDisplaySettings: (memoryArguments: Partial<MemoryDataDisplaySettings>) => void;
     updateTitle: (title: string) => void;
     fetchMemory(partialOptions?: MemoryOptions): Promise<void>;
     storeMemory(): void;
@@ -67,15 +69,16 @@ export class MemoryWidget extends React.Component<MemoryWidgetProps, MemoryWidge
 
     protected createVscodeContext(): VscodeContext {
         const visibleColumns = this.props.columns.filter(candidate => candidate.active).map(column => column.contribution.id);
-        const { messageParticipant, showRadixPrefix, endianness, bytesPerMau, activeReadArguments } = this.props;
+        const { messageParticipant, showRadixPrefix, endianness, bytesPerMau, activeReadArguments, hasDebuggerDefaults } = this.props;
         return createAppVscodeContext({
             messageParticipant,
             showRadixPrefix,
-            showAsciiColumn: visibleColumns.includes('ascii'),
-            showVariablesColumn: visibleColumns.includes('variables'),
+            showAsciiColumn: visibleColumns.includes(manifest.CONFIG_SHOW_ASCII_COLUMN),
+            showVariablesColumn: visibleColumns.includes(manifest.CONFIG_SHOW_VARIABLES_COLUMN),
+            activeReadArguments,
+            hasDebuggerDefaults,
             endianness,
             bytesPerMau,
-            activeReadArguments
         });
 
     }
@@ -98,11 +101,11 @@ export class MemoryWidget extends React.Component<MemoryWidgetProps, MemoryWidge
                 periodicRefresh={this.props.periodicRefresh}
                 periodicRefreshInterval={this.props.periodicRefreshInterval}
                 updateMemoryState={this.props.updateMemoryState}
-                updateRenderOptions={this.props.updateMemoryDisplayConfiguration}
-                resetRenderOptions={this.props.resetMemoryDisplayConfiguration}
+                updateRenderOptions={this.props.updateMemoryDisplaySettings}
                 addressPadding={this.props.addressPadding}
                 addressRadix={this.props.addressRadix}
                 showRadixPrefix={this.props.showRadixPrefix}
+                settingsContributionMessage={this.props.settingsContributionMessage}
                 fetchMemory={this.props.fetchMemory}
                 toggleColumn={this.props.toggleColumn}
                 toggleFrozen={this.props.toggleFrozen}

--- a/src/webview/components/multi-select.tsx
+++ b/src/webview/components/multi-select.tsx
@@ -25,12 +25,13 @@ export interface SingleSelectItemProps {
 
 interface MultiSelectProps {
     items: SingleSelectItemProps[];
-    label: string;
+    label?: string;
     id?: string;
+    classNames?: string;
     onSelectionChanged: (labelSelected: string, newSelectionState: boolean) => unknown;
 }
 
-const MultiSelectBar: React.FC<MultiSelectProps> = ({ items, onSelectionChanged, id }) => {
+export const MultiSelectBar: React.FC<MultiSelectProps> = ({ items, onSelectionChanged, id }) => {
     const changeHandler: ((e: CheckboxChangeEvent) => unknown) = React.useCallback(e => {
         const target = e.target as HTMLInputElement;
         if (target) {
@@ -54,10 +55,3 @@ const MultiSelectBar: React.FC<MultiSelectProps> = ({ items, onSelectionChanged,
         </div>
     );
 };
-
-export const MultiSelectWithLabel: React.FC<MultiSelectProps> = ({ id, label, items, onSelectionChanged }) => (
-    <div className='flex flex-column'>
-        <h2 className='multi-select-label mb-2 mt-0'>{label}</h2>
-        <MultiSelectBar id={id} items={items} onSelectionChanged={onSelectionChanged} label={label} />
-    </div>
-);

--- a/src/webview/components/options-widget.tsx
+++ b/src/webview/components/options-widget.tsx
@@ -15,6 +15,7 @@
  ********************************************************************************/
 
 import { Formik, FormikConfig, FormikErrors, FormikProps } from 'formik';
+import { Accordion, AccordionTab, AccordionTabChangeEvent } from 'primereact/accordion';
 import { Button } from 'primereact/button';
 import { Checkbox } from 'primereact/checkbox';
 import { Dropdown, DropdownChangeEvent } from 'primereact/dropdown';
@@ -31,7 +32,7 @@ import { TableRenderOptions } from '../columns/column-contribution-service';
 import { DEFAULT_MEMORY_DISPLAY_CONFIGURATION } from '../memory-webview-view';
 import { AddressPaddingOptions, DEFAULT_READ_ARGUMENTS, MemoryState, SerializedTableRenderOptions } from '../utils/view-types';
 import { createSectionVscodeContext } from '../utils/vscode-contexts';
-import { MultiSelectWithLabel } from './multi-select';
+import { MultiSelectBar } from './multi-select';
 
 export interface OptionsWidgetProps
     extends Omit<TableRenderOptions, 'scrollingBehavior' | 'effectiveAddressLength'> {
@@ -53,6 +54,10 @@ export interface OptionsWidgetProps
 
 interface OptionsWidgetState {
     isTitleEditing: boolean;
+    showColumnsOptions: boolean;
+    showMemoryOptions: boolean;
+    showAddressOptions: boolean;
+    showRefreshOptions: boolean;
 }
 
 const enum InputId {
@@ -85,6 +90,12 @@ export class OptionsWidget extends React.Component<OptionsWidgetProps, OptionsWi
     protected coreOptionsDiv = React.createRef<HTMLDivElement>();
     protected optionsMenuContext = createSectionVscodeContext('optionsWidget');
     protected advancedOptionsContext = createSectionVscodeContext('advancedOptionsOverlay');
+    protected advancedOptionsSections: { key: keyof OptionsWidgetState, index: number }[] = [
+        { key: 'showColumnsOptions', index: 0 },
+        { key: 'showMemoryOptions', index: 1 },
+        { key: 'showAddressOptions', index: 2 },
+        { key: 'showRefreshOptions', index: 3 }
+    ];
 
     protected get optionsFormValues(): OptionsForm {
         return {
@@ -103,7 +114,13 @@ export class OptionsWidget extends React.Component<OptionsWidgetProps, OptionsWi
             validate: this.validate,
             onSubmit: () => this.props.fetchMemory(this.props.configuredReadArguments),
         };
-        this.state = { isTitleEditing: false };
+        this.state = {
+            isTitleEditing: false,
+            showColumnsOptions: false,
+            showMemoryOptions: true,
+            showAddressOptions: false,
+            showRefreshOptions: true
+        };
     }
 
     protected validate = (values: OptionsForm) => {
@@ -286,7 +303,12 @@ export class OptionsWidget extends React.Component<OptionsWidgetProps, OptionsWi
                             </form>
                         )}
                     </Formik>
-                    <OverlayPanel className='advanced-options-panel' ref={this.extendedOptions} {...this.advancedOptionsContext}>
+                    <OverlayPanel
+                        appendTo={this.coreOptionsDiv.current}
+                        className='advanced-options-panel'
+                        ref={this.extendedOptions}
+                        {...this.advancedOptionsContext}>
+                        <h2 className='advanced-options-header'>Advanced Options</h2>
                         <Button
                             icon='codicon codicon-discard'
                             className='reset-advanced-options-icon'
@@ -296,161 +318,171 @@ export class OptionsWidget extends React.Component<OptionsWidgetProps, OptionsWi
                             aria-label='Reset to Defaults'
                             aria-haspopup
                         />
-                        <div className='advanced-options-content'>
+                        <Accordion
+                            multiple
+                            activeIndex={this.getActiveAdvancedOptionSectionIndices()}
+                            className='advanced-options-accordion'
+                            onTabChange={this.onAdvancedOptionsTabChange}
+                        >
                             {!!this.props.columnOptions.length && (
-                                <MultiSelectWithLabel
-                                    id='column-select'
-                                    label='Columns'
-                                    items={this.props.columnOptions
-                                        .filter(({ configurable }) => configurable)
-                                        .map(column => ({
-                                            id: column.contribution.id,
-                                            label: column.contribution.label,
-                                            checked: column.active,
-                                        }))}
-                                    onSelectionChanged={this.handleColumnActivationChange}
-                                />
+                                <AccordionTab header='Columns'>
+                                    <div className='advanced-options-content mt-2'>
+                                        <MultiSelectBar
+                                            id='column-select'
+                                            classNames='advanced-options-content'
+                                            items={this.props.columnOptions
+                                                .filter(({ configurable }) => configurable)
+                                                .map(column => ({
+                                                    id: column.contribution.id,
+                                                    label: column.contribution.label,
+                                                    checked: column.active,
+                                                }))}
+                                            onSelectionChanged={this.handleColumnActivationChange}
+                                        />
+                                    </div>
+                                </AccordionTab>
                             )}
 
-                            <h2>Memory Format
-                                <a
-                                    href='https://github.com/eclipse-cdt-cloud/vscode-memory-inspector?tab=readme-ov-file#memory-format-settings'
-                                    className='no-text-decoration'
-                                >
-                                    <span className='codicon codicon-question option-help-icon'></span>
-                                </a>
-                            </h2>
-                            <label
-                                htmlFor={InputId.BytesPerMau}
-                                className='advanced-options-label'
-                            >
-                                Bytes per <abbr className='no-text-decoration' title='Minimum Addressable Unit'>MAU</abbr>
-                            </label>
-                            <Dropdown
-                                id={InputId.BytesPerMau}
-                                value={this.props.bytesPerMau}
-                                onChange={this.handleAdvancedOptionsDropdownChange}
-                                options={[...CONFIG_BYTES_PER_MAU_CHOICES]}
-                                className='advanced-options-dropdown' />
+                            <AccordionTab header='Memory Format'>
+                                <div className='advanced-options-content'>
+                                    <label
+                                        htmlFor={InputId.BytesPerMau}
+                                        className='advanced-options-label'
+                                    >
+                                        Bytes per <abbr className='no-text-decoration' title='Minimum Addressable Unit'>MAU</abbr>
+                                    </label>
+                                    <Dropdown
+                                        id={InputId.BytesPerMau}
+                                        value={this.props.bytesPerMau}
+                                        onChange={this.handleAdvancedOptionsDropdownChange}
+                                        options={[...CONFIG_BYTES_PER_MAU_CHOICES]}
+                                        className='advanced-options-dropdown' />
 
-                            <label
-                                htmlFor={InputId.MausPerGroup}
-                                className='advanced-options-label'
-                            >
-                                <abbr className='no-text-decoration' title='Minimum Addressable Units'>MAUs</abbr> per Group
-                            </label>
-                            <Dropdown
-                                id={InputId.MausPerGroup}
-                                value={this.props.mausPerGroup}
-                                onChange={this.handleAdvancedOptionsDropdownChange}
-                                options={[...CONFIG_MAUS_PER_GROUP_CHOICES]}
-                                className='advanced-options-dropdown' />
-                            <label
-                                htmlFor={InputId.GroupsPerRow}
-                                className='advanced-options-label'
-                            >
-                                Groups per Row
-                            </label>
-                            <Dropdown
-                                id={InputId.GroupsPerRow}
-                                value={this.props.groupsPerRow}
-                                onChange={this.handleAdvancedOptionsDropdownChange}
-                                options={[...CONFIG_GROUPS_PER_ROW_CHOICES]}
-                                className='advanced-options-dropdown' />
+                                    <label
+                                        htmlFor={InputId.MausPerGroup}
+                                        className='advanced-options-label'
+                                    >
+                                        <abbr className='no-text-decoration' title='Minimum Addressable Units'>MAUs</abbr> per Group
+                                    </label>
+                                    <Dropdown
+                                        id={InputId.MausPerGroup}
+                                        value={this.props.mausPerGroup}
+                                        onChange={this.handleAdvancedOptionsDropdownChange}
+                                        options={[...CONFIG_MAUS_PER_GROUP_CHOICES]}
+                                        className='advanced-options-dropdown' />
+                                    <label
+                                        htmlFor={InputId.GroupsPerRow}
+                                        className='advanced-options-label'
+                                    >
+                                        Groups per Row
+                                    </label>
+                                    <Dropdown
+                                        id={InputId.GroupsPerRow}
+                                        value={this.props.groupsPerRow}
+                                        onChange={this.handleAdvancedOptionsDropdownChange}
+                                        options={[...CONFIG_GROUPS_PER_ROW_CHOICES]}
+                                        className='advanced-options-dropdown' />
 
-                            <label
-                                htmlFor={InputId.EndiannessId}
-                                className='advanced-options-label'
-                            >
-                                Group Endianness
-                            </label>
-                            <Dropdown
-                                id={InputId.EndiannessId}
-                                value={this.props.endianness}
-                                onChange={this.handleAdvancedOptionsDropdownChange}
-                                options={[...ENDIANNESS_CHOICES]}
-                                className='advanced-options-dropdown' />
+                                    <label
+                                        htmlFor={InputId.EndiannessId}
+                                        className='advanced-options-label'
+                                    >
+                                        Group Endianness
+                                    </label>
+                                    <Dropdown
+                                        id={InputId.EndiannessId}
+                                        value={this.props.endianness}
+                                        onChange={this.handleAdvancedOptionsDropdownChange}
+                                        options={[...ENDIANNESS_CHOICES]}
+                                        className='advanced-options-dropdown' />
+                                </div>
+                            </AccordionTab>
 
-                            <h2>Address Format</h2>
+                            <AccordionTab header='Address Format'>
+                                <div className='advanced-options-content'>
+                                    <label
+                                        htmlFor={InputId.AddressPadding}
+                                        className='advanced-options-label'
+                                    >
+                                        Padding
+                                    </label>
+                                    <Dropdown
+                                        id={InputId.AddressPadding}
+                                        value={this.props.addressPadding}
+                                        onChange={this.handleAdvancedOptionsDropdownChange}
+                                        options={Object.entries(AddressPaddingOptions).map(([label, value]) => ({ label, value }))}
+                                        className="advanced-options-dropdown" />
 
-                            <label
-                                htmlFor={InputId.AddressPadding}
-                                className='advanced-options-label'
-                            >
-                                Padding
-                            </label>
-                            <Dropdown
-                                id={InputId.AddressPadding}
-                                value={this.props.addressPadding}
-                                onChange={this.handleAdvancedOptionsDropdownChange}
-                                options={Object.entries(AddressPaddingOptions).map(([label, value]) => ({ label, value }))}
-                                className="advanced-options-dropdown" />
+                                    <label
+                                        htmlFor={InputId.AddressRadix}
+                                        className='advanced-options-label'
+                                    >
+                                        Format (Radix)
+                                    </label>
+                                    <Dropdown
+                                        id={InputId.AddressRadix}
+                                        value={Number(this.props.addressRadix)}
+                                        onChange={this.handleAdvancedOptionsDropdownChange}
+                                        options={[
+                                            { label: '2 - Binary', value: 2 },
+                                            { label: '8 - Octal', value: 8 },
+                                            { label: '10 - Decimal', value: 10 },
+                                            { label: '16 - Hexadecimal', value: 16 }
+                                        ]}
+                                        className="advanced-options-dropdown" />
+                                    <div className='flex align-items-center mt-2'>
+                                        <Checkbox
+                                            id={InputId.ShowRadixPrefix}
+                                            onChange={this.handleAdvancedOptionsDropdownChange}
+                                            checked={!!this.props.showRadixPrefix}
+                                        />
+                                        <label htmlFor={InputId.ShowRadixPrefix} className='ml-2'>Display Radix Prefix</label>
+                                    </div>
+                                </div>
+                            </AccordionTab>
 
-                            <label
-                                htmlFor={InputId.AddressRadix}
-                                className='advanced-options-label'
-                            >
-                                Format (Radix)
-                            </label>
-                            <Dropdown
-                                id={InputId.AddressRadix}
-                                value={Number(this.props.addressRadix)}
-                                onChange={this.handleAdvancedOptionsDropdownChange}
-                                options={[
-                                    { label: '2 - Binary', value: 2 },
-                                    { label: '8 - Octal', value: 8 },
-                                    { label: '10 - Decimal', value: 10 },
-                                    { label: '16 - Hexadecimal', value: 16 }
-                                ]}
-                                className="advanced-options-dropdown" />
+                            <AccordionTab header='Refresh Options'>
+                                <div className='advanced-options-content mt-2 mb-0'>
+                                    <div className='flex align-items-center'>
+                                        <Checkbox
+                                            id={InputId.RefreshOnStop}
+                                            onChange={this.handleAdvancedOptionsDropdownChange}
+                                            checked={this.props.refreshOnStop === 'on'}
+                                        />
+                                        <label htmlFor={InputId.ShowRadixPrefix} className='ml-2'>Refresh On Stop</label>
+                                    </div>
 
-                            <div className='flex align-items-center mt-2'>
-                                <Checkbox
-                                    id={InputId.ShowRadixPrefix}
-                                    onChange={this.handleAdvancedOptionsDropdownChange}
-                                    checked={!!this.props.showRadixPrefix}
-                                />
-                                <label htmlFor={InputId.ShowRadixPrefix} className='ml-2'>Display Radix Prefix</label>
-                            </div>
+                                    <label htmlFor={InputId.PeriodicRefresh} className='advanced-options-label mt-2'>Periodic Refresh</label>
+                                    <Dropdown
+                                        id={InputId.PeriodicRefresh}
+                                        value={this.props.periodicRefresh}
+                                        onChange={this.handleAdvancedOptionsDropdownChange}
+                                        options={[...PERIODIC_REFRESH_CHOICES]}
+                                        className="advanced-options-dropdown" />
 
-                            <h2>Refresh</h2>
-                            <div className='flex align-items-center mt-2'>
-                                <Checkbox
-                                    id={InputId.RefreshOnStop}
-                                    onChange={this.handleAdvancedOptionsDropdownChange}
-                                    checked={this.props.refreshOnStop === 'on'}
-                                />
-                                <label htmlFor={InputId.ShowRadixPrefix} className='ml-2'>Refresh On Stop</label>
-                            </div>
+                                    <div className='flex align-items-center mt-2'>
+                                        <InputNumber
+                                            id={InputId.PeriodicRefreshInterval}
+                                            ref={this.refreshRateInput}
+                                            disabled={this.props.periodicRefresh === 'off'}
+                                            value={this.props.periodicRefreshInterval}
+                                            placeholder='Interval in ms'
+                                            inputClassName='advanced-options-input'
+                                            min={500}
+                                            step={250}
+                                            maxFractionDigits={0}
+                                            useGrouping={false}
+                                            onBlur={this.handlePeriodicRefreshIntervalChange}
+                                            onKeyDown={this.handlePeriodicRefreshIntervalChange} />
+                                        <label htmlFor={InputId.PeriodicRefreshInterval} className='ml-2'>ms</label>
+                                    </div>
+                                </div>
+                            </AccordionTab>
 
-                            <label htmlFor={InputId.PeriodicRefresh} className='advanced-options-label mt-2'>Periodic Refresh</label>
-                            <Dropdown
-                                id={InputId.PeriodicRefresh}
-                                value={this.props.periodicRefresh}
-                                onChange={this.handleAdvancedOptionsDropdownChange}
-                                options={[...PERIODIC_REFRESH_CHOICES]}
-                                className="advanced-options-dropdown" />
-
-                            <div className='flex align-items-center mt-2'>
-                                <InputNumber
-                                    id={InputId.PeriodicRefreshInterval}
-                                    ref={this.refreshRateInput}
-                                    disabled={this.props.periodicRefresh === 'off'}
-                                    value={this.props.periodicRefreshInterval}
-                                    placeholder='Interval in ms'
-                                    inputClassName='advanced-options-input'
-                                    min={500}
-                                    step={250}
-                                    maxFractionDigits={0}
-                                    useGrouping={false}
-                                    onBlur={this.handlePeriodicRefreshIntervalChange}
-                                    onKeyDown={this.handlePeriodicRefreshIntervalChange} />
-                                <label htmlFor={InputId.PeriodicRefreshInterval} className='ml-2'>ms</label>
-                            </div>
-                        </div>
+                        </Accordion>
                     </OverlayPanel>
-                </div>
-            </div>
+                </div >
+            </div >
         );
     }
 
@@ -605,6 +637,22 @@ export class OptionsWidget extends React.Component<OptionsWidgetProps, OptionsWi
                 this.coreOptionsDiv.current.querySelector<HTMLButtonElement>('.advanced-options-toggle')?.click();
             }
         }
+    }
+
+    protected getActiveAdvancedOptionSectionIndices(): number[] {
+        return this.advancedOptionsSections
+            .filter(option => this.state[option.key])
+            .map(option => option.index);
+    }
+
+    protected onAdvancedOptionsTabChange: (event: AccordionTabChangeEvent) => void = event => this.doAdvancedOptionsTabChange(event);
+    protected doAdvancedOptionsTabChange(event: AccordionTabChangeEvent): void {
+        const activeIndices = Array.isArray(event.index) ? event.index : [event.index];
+        const newState = this.advancedOptionsSections.reduce((acc, option) => {
+            acc[option.key] = activeIndices.includes(option.index);
+            return acc;
+        }, {} as OptionsWidgetState);
+        this.setState(newState);
     }
 
 }

--- a/src/webview/hovers/hover-service.tsx
+++ b/src/webview/hovers/hover-service.tsx
@@ -17,7 +17,7 @@
 import * as React from 'react';
 import { HOST_EXTENSION } from 'vscode-messenger-common';
 import { logMessageType } from '../../common/messaging';
-import { MemoryDisplayConfiguration } from '../../common/webview-configuration';
+import { MemoryDataDisplaySettings } from '../../common/webview-configuration';
 import { MemoryAppState } from '../memory-webview-view';
 import { Disposable } from '../utils/view-types';
 import { messenger } from '../view-messenger';
@@ -29,7 +29,7 @@ export interface HoverableDetails {
     extraData: any;
 }
 
-export interface MemoryDetails extends HoverableDetails, MemoryDisplayConfiguration, MemoryAppState { };
+export interface MemoryDetails extends HoverableDetails, MemoryDataDisplaySettings, MemoryAppState { };
 
 export type HoverProvider = (data: MemoryDetails) => Promise<React.ReactNode>;
 

--- a/src/webview/hovers/variable-hover.tsx
+++ b/src/webview/hovers/variable-hover.tsx
@@ -15,6 +15,7 @@
  ********************************************************************************/
 
 import * as React from 'react';
+import * as manifest from '../../common/manifest';
 import { VariableRange } from '../../common/memory-range';
 import { HoverContribution, MemoryDetails } from './hover-service';
 
@@ -25,7 +26,7 @@ export class VariableHover implements HoverContribution {
     async render(
         { columnId, bytesPerMau, extraData }: MemoryDetails,
     ): Promise<React.ReactNode> {
-        if (columnId !== 'variables') { return; }
+        if (columnId !== manifest.CONFIG_SHOW_VARIABLES_COLUMN) { return; }
 
         const { type, startAddress, endAddress, name } = extraData as VariableRange;
         const start = '0x' + parseInt(startAddress).toString(16);

--- a/src/webview/utils/view-types.ts
+++ b/src/webview/utils/view-types.ts
@@ -16,15 +16,13 @@
 
 import deepequal from 'fast-deep-equal';
 import type * as React from 'react';
-import { Endianness } from '../../common/manifest';
 import { Memory } from '../../common/memory';
 import { areRangesEqual, BigIntMemoryRange } from '../../common/memory-range';
 import { ReadMemoryArguments } from '../../common/messaging';
-import { MemoryDisplayConfiguration } from '../../common/webview-configuration';
+import { MemoryDataDisplaySettings } from '../../common/webview-configuration';
 
-export interface SerializedTableRenderOptions extends MemoryDisplayConfiguration {
+export interface SerializedTableRenderOptions extends MemoryDataDisplaySettings {
     columnOptions: Array<{ label: string, doRender: boolean }>;
-    endianness: Endianness;
     effectiveAddressLength: number;
 }
 
@@ -80,7 +78,7 @@ export interface FullNodeAttributes extends StylableNodeAttributes {
 }
 
 export const AddressPaddingOptions = {
-    'Minimal': 'Minimal',
+    'Minimal': 'Min',
     'Unpadded': 0,
     '32bit': 32,
     '64bit': 64,

--- a/src/webview/utils/vscode-contexts.ts
+++ b/src/webview/utils/vscode-contexts.ts
@@ -52,6 +52,10 @@ export function createSectionVscodeContext(webviewSection: WebviewSection): Vsco
     return createVscodeContext({ webviewSection });
 }
 
+export function createOverlayMoreActionsVscodeContext(): VscodeContext {
+    return createVscodeContext({ webviewSection: 'advancedOptionsOverlay', advancedOptions: true, optionsMenu: true });
+}
+
 export function createColumnVscodeContext(column: string): VscodeContext {
     return createVscodeContext({ column });
 }

--- a/src/webview/variables/variable-decorations.ts
+++ b/src/webview/variables/variable-decorations.ts
@@ -17,6 +17,7 @@
 import { ReactNode } from 'react';
 import * as React from 'react';
 import { HOST_EXTENSION } from 'vscode-messenger-common';
+import * as manifest from '../../common/manifest';
 import { areVariablesEqual, BigIntMemoryRange, BigIntVariableRange, compareBigInt, doOverlap } from '../../common/memory-range';
 import { getVariablesType, ReadMemoryArguments } from '../../common/messaging';
 import { stringifyWithBigInts } from '../../common/typescript';
@@ -36,7 +37,7 @@ const NON_HC_COLORS = [
 ] as const;
 
 export class VariableDecorator implements ColumnContribution, Decorator {
-    readonly id = 'variables';
+    readonly id = manifest.CONFIG_SHOW_VARIABLES_COLUMN;
     readonly label = 'Variables';
     readonly priority = 2;
     protected active = false;


### PR DESCRIPTION
#### What it does
Extenders can use the `AdapterCapabilities` to specify their own default settings, including the visible columns (see `MemoryDisplaySettings` interface). If an extension specifies such settings for a specific debug session (or type), those settings take priority over the user's VS Code settings of the Memory Inspector. To indicate that default settings are overwritten by an extension, an additional message can be provided by the extension shown at the bottom of the options overlay.

![image](https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/assets/588090/8d78f801-2786-4023-b04a-fb8be97bbc31)

Users can prevent extenders from overwriting the default settings via a dedicated VS Code
setting (`allowSettingsExtension`).

As we now have two levels of defaults, this change also replaces the reset button with a `...` button opening a drop-down menu similar to the view menus in VS Code. This menu contains two reset entries, if the debugger extension provided defaults; one for resetting to debugger defaults, the other one for resetting to VS Code defaults.

This also enables adding additional context menu entries via the usual VS Code menu contribution point, which can be used by extenders. In this change we already make use of it, to control the visibility of sections in the options overlay. We also hide columns and address format by default, because the columns can easily be enabled and disabled via context menu anyway, and address format is less-frequently changed by users.

Fixes https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/issues/77

#### How to test
To properly test this, you need to set up another extension that registers an adapter.
I've published the one I've used for testing:
https://github.com/planger/customize-memory-inspector/commits/planger/issues/77/

Once you have contributed settings, you can test whether they are used correctly, and whether the reset buttons work correctly.

Aside from that you can check whether switching the visibility of option overlay sections work as expected.

#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the contribution guidelines](https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/blob/main/CONTRIBUTING.md)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the code of conduct](https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/blob/main/CODE_OF_CONDUCT.md)
