### PR TITLE
General improvements of the styling

### DIFF
--- a/media/memory-table.css
+++ b/media/memory-table.css
@@ -139,7 +139,8 @@
 
 /* Colors for the hover fields */
 .memory-hover .label-value-pair>.label {
-  color: var(--vscode-debugTokenExpression-string);
+    color: var(--vscode-debugTokenExpression-string);
+    white-space: nowrap;
 }
 .memory-hover .label-value-pair>.value {
   color: var(--vscode-debugTokenExpression-number);

--- a/media/options-widget.css
+++ b/media/options-widget.css
@@ -16,27 +16,23 @@
 
 .memory-options-widget {
   margin-bottom: 8px;
-  padding-bottom: 4px;
 }
 
 .memory-options-widget .title-container {
   display: flex;
   align-items: center;
+  margin-top: 4px;
 }
 
 .memory-options-widget .title-container h1 {
   flex-grow: 1;
   font-size: 1.3em;
-  margin: 8px 5px 4px;
+  margin: 8px 5px 5px;
 }
 
 .memory-options-widget .title-container input {
   margin: 5px 0 0;
   flex-grow: 1;
-}
-
-.memory-options-widget .p-button {
-  align-self: end;
 }
 
 .memory-options-widget .edit-label-toggle {
@@ -64,6 +60,7 @@
   flex-wrap: wrap;
   border-bottom: 1px solid var(--vscode-widget-border);
   border-top: 1px solid var(--vscode-widget-border);
+  padding-top: 0.5rem;
 }
 
 .form-options {
@@ -72,7 +69,7 @@
   align-items: start;
   flex-wrap: wrap;
   column-gap: 12px;
-  row-gap: 12px;
+  width: 100%;
 }
 
 .form-textfield {
@@ -101,15 +98,19 @@
   color: var(--vscode-descriptionForeground);
 }
 
+.advanced-options-content {
+  color: var(--vscode-settings-headerForeground);
+}
+
 .advanced-options-content h2 {
-  font-size: 120%;
-  margin: 0.5rem 0 0 0;
+  font-size: 110%;
+  margin: 1.2rem 0 0 0;
 }
 
 .advanced-options-toggle {
   margin-left: auto;
   align-self: start;
-  margin-top: 1rem;
+  margin-top: 1.1rem
 }
 
 .advanced-options-content {
@@ -117,7 +118,6 @@
   text-align: left;
   display: flex;
   flex-direction: column;
-  gap: 8px;
 }
 
 .advanced-options-dropdown {
@@ -126,16 +126,30 @@
 
 .advanced-options-label {
   width: 100%;
-  font-weight: bold;
+  margin: 0.5rem 0 0.2rem 0;
 }
 
 .reset-advanced-options-icon {
   position: absolute;
   top: 12px;
-  right: 12px;
+  right: 0;
   border: none;
   background-color: transparent;
   cursor: pointer;
+}
+
+.advanced-options-panel {
+  overflow-y: scroll;
+  max-height: 100%;
+  margin-top: 0px;
+}
+.advanced-options-panel::-webkit-scrollbar-track {
+  background-color: var(--vscode-dropdown-listBackground);
+}
+
+.advanced-options-panel .p-overlaypanel-content {
+  background-color: var(--vscode-dropdown-listBackground);
+  padding-right: 6px;
 }
 
 .no-text-decoration {

--- a/src/webview/components/options-widget.tsx
+++ b/src/webview/components/options-widget.tsx
@@ -199,7 +199,7 @@ export class OptionsWidget extends React.Component<OptionsWidgetProps, OptionsWi
                         </>
                     )}
                 </div>
-                <div className='core-options py-2' ref={this.coreOptionsDiv}>
+                <div className='core-options' ref={this.coreOptionsDiv}>
                     <Formik {...this.formConfig}>
                         {formik => (
                             <form onSubmit={formik.handleSubmit} className='form-options'>
@@ -263,22 +263,22 @@ export class OptionsWidget extends React.Component<OptionsWidgetProps, OptionsWi
                                 <Button type='submit' disabled={!formik.isValid || readDisabled}>
                                     Go
                                 </Button>
+                                <Button
+                                    className='advanced-options-toggle'
+                                    icon='codicon codicon-gear'
+                                    onClick={event =>
+                                        this.extendedOptions?.current?.toggle(event)
+                                    }
+                                    type='button'
+                                    title='Advanced Display Options'
+                                    rounded
+                                    aria-label='Advanced Display Options'
+                                    aria-haspopup
+                                ></Button>
                             </form>
                         )}
                     </Formik>
-                    <Button
-                        className='advanced-options-toggle'
-                        icon='codicon codicon-gear'
-                        onClick={event =>
-                            this.extendedOptions?.current?.toggle(event)
-                        }
-                        type='button'
-                        title='Advanced Display Options'
-                        rounded
-                        aria-label='Advanced Display Options'
-                        aria-haspopup
-                    ></Button>
-                    <OverlayPanel ref={this.extendedOptions} {...this.advancedOptionsContext}>
+                    <OverlayPanel className='advanced-options-panel' ref={this.extendedOptions} {...this.advancedOptionsContext}>
                         <Button
                             icon='codicon codicon-discard'
                             className='reset-advanced-options-icon'
@@ -314,7 +314,7 @@ export class OptionsWidget extends React.Component<OptionsWidgetProps, OptionsWi
                             </h2>
                             <label
                                 htmlFor={InputId.BytesPerMau}
-                                className='advanced-options-label mt-1'
+                                className='advanced-options-label'
                             >
                                 Bytes per <abbr className='no-text-decoration' title='Minimum Addressable Unit'>MAU</abbr>
                             </label>
@@ -327,7 +327,7 @@ export class OptionsWidget extends React.Component<OptionsWidgetProps, OptionsWi
 
                             <label
                                 htmlFor={InputId.MausPerGroup}
-                                className='advanced-options-label mt-1'
+                                className='advanced-options-label'
                             >
                                 <abbr className='no-text-decoration' title='Minimum Addressable Units'>MAUs</abbr> per Group
                             </label>
@@ -352,7 +352,7 @@ export class OptionsWidget extends React.Component<OptionsWidgetProps, OptionsWi
 
                             <label
                                 htmlFor={InputId.EndiannessId}
-                                className='advanced-options-label mt-1'
+                                className='advanced-options-label'
                             >
                                 Group Endianness
                             </label>
@@ -369,7 +369,7 @@ export class OptionsWidget extends React.Component<OptionsWidgetProps, OptionsWi
                                 htmlFor={InputId.AddressPadding}
                                 className='advanced-options-label'
                             >
-                                Address Padding
+                                Padding
                             </label>
                             <Dropdown
                                 id={InputId.AddressPadding}
@@ -396,7 +396,7 @@ export class OptionsWidget extends React.Component<OptionsWidgetProps, OptionsWi
                                 ]}
                                 className="advanced-options-dropdown" />
 
-                            <div className='flex align-items-center'>
+                            <div className='flex align-items-center mt-2'>
                                 <Checkbox
                                     id={InputId.ShowRadixPrefix}
                                     onChange={this.handleAdvancedOptionsDropdownChange}


### PR DESCRIPTION
#### What it does

* Properly aligning the icons in the memory widget
* Aligning and line breaking in the address / offset / length area
* Better spacing and coloring in the advanced options overlay
* Adding own scrollbar in the advanced options overlay
* Avoid line breaking in the label column of the hover

![image](https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/assets/588090/44c0320a-ce89-49fb-8c47-e82e80ca4d70)

![image](https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/assets/588090/6905f91c-54fa-426e-bbb3-c75f3311040d)

![image](https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/assets/588090/c3be7407-f002-4c14-bfe0-31e03066fb6c)


#### How to test
Test how you feel the layouting looks in the upper part of the memory inspector and the options overlay. Try different themes too. Also try resizing the view to observe how the flex components break into new lines.

#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the contribution guidelines](https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/blob/main/CONTRIBUTING.md)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the code of conduct](https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/blob/main/CODE_OF_CONDUCT.md)
