### PR TITLE
Add validation for invalid memory references

### DIFF
--- a/src/webview/components/options-widget.tsx
+++ b/src/webview/components/options-widget.tsx
@@ -28,6 +28,7 @@ import { MemoryOptions, ReadMemoryArguments, SessionContext } from '../../common
 import { tryToNumber } from '../../common/typescript';
 import { CONFIG_BYTES_PER_MAU_CHOICES, CONFIG_GROUPS_PER_ROW_CHOICES, CONFIG_MAUS_PER_GROUP_CHOICES } from '../../plugin/manifest';
 import { TableRenderOptions } from '../columns/column-contribution-service';
+import { DEFAULT_READ_ARGUMENTS } from '../memory-webview-view';
 import { AddressPaddingOptions, MemoryState, SerializedTableRenderOptions } from '../utils/view-types';
 import { createSectionVscodeContext } from '../utils/vscode-contexts';
 import { MultiSelectWithLabel } from './multi-select';
@@ -120,10 +121,13 @@ export class OptionsWidget extends React.Component<OptionsWidgetProps, OptionsWi
         return errors;
     };
 
-    componentDidUpdate(_: Readonly<OptionsWidgetProps>, prevState: Readonly<OptionsWidgetState>): void {
+    componentDidUpdate(prevProps: Readonly<OptionsWidgetProps>, prevState: Readonly<OptionsWidgetState>): void {
         if (!prevState.isTitleEditing && this.state.isTitleEditing) {
             this.labelEditInput.current?.focus();
             this.labelEditInput.current?.select();
+        }
+        if (prevProps.activeReadArguments === DEFAULT_READ_ARGUMENTS) {
+            this.formConfig.initialErrors = this.validate(this.optionsFormValues);
         }
     }
 

--- a/src/webview/components/options-widget.tsx
+++ b/src/webview/components/options-widget.tsx
@@ -28,8 +28,7 @@ import { MemoryOptions, ReadMemoryArguments, SessionContext } from '../../common
 import { tryToNumber } from '../../common/typescript';
 import { CONFIG_BYTES_PER_MAU_CHOICES, CONFIG_GROUPS_PER_ROW_CHOICES, CONFIG_MAUS_PER_GROUP_CHOICES } from '../../plugin/manifest';
 import { TableRenderOptions } from '../columns/column-contribution-service';
-import { DEFAULT_READ_ARGUMENTS } from '../memory-webview-view';
-import { AddressPaddingOptions, MemoryState, SerializedTableRenderOptions } from '../utils/view-types';
+import { AddressPaddingOptions, DEFAULT_READ_ARGUMENTS, MemoryState, SerializedTableRenderOptions } from '../utils/view-types';
 import { createSectionVscodeContext } from '../utils/vscode-contexts';
 import { MultiSelectWithLabel } from './multi-select';
 
@@ -106,7 +105,7 @@ export class OptionsWidget extends React.Component<OptionsWidgetProps, OptionsWi
 
     protected validate = (values: OptionsForm) => {
         const errors: FormikErrors<OptionsForm> = {};
-        const addressError = values.address.trim().length === 0 ? 'Required' : validateMemoryReference(values.address);
+        const addressError = values.address.trim().length === 0 ? 'Required' : validateMemoryReference(values.address.trim());
         if (addressError) {
             errors.address = addressError;
         }
@@ -138,9 +137,11 @@ export class OptionsWidget extends React.Component<OptionsWidgetProps, OptionsWi
         const readDisabled = isFrozen || !this.props.sessionContext.canRead;
         const freezeContentToggleTitle = isFrozen ? 'Unfreeze Memory View' : 'Freeze Memory View';
         const activeMemoryReadArgumentHint = (userValue: string | number, memoryValue: string | number): ReactNode | undefined => {
-            if (userValue !== memoryValue) {
-                return <small className="form-options-memory-read-argument-hint">Actual: {memoryValue}</small>;
+            if (userValue === memoryValue || this.props.activeReadArguments === DEFAULT_READ_ARGUMENTS) {
+                return undefined;
             }
+            return <small className="form-options-memory-read-argument-hint">Actual: {memoryValue}</small>;
+
         };
 
         return (
@@ -442,12 +443,12 @@ export class OptionsWidget extends React.Component<OptionsWidgetProps, OptionsWi
                 this.props.updateMemoryState({
                     configuredReadArguments: {
                         ...this.props.configuredReadArguments,
-                        memoryReference: value,
+                        memoryReference: value.trim(),
                     }
                 });
                 break;
             case InputId.Offset:
-                if (!Number.isNaN(value)) {
+                if (!!value && !Number.isNaN(value)) {
                     this.props.updateMemoryState({
                         configuredReadArguments: {
                             ...this.props.configuredReadArguments,
@@ -457,7 +458,7 @@ export class OptionsWidget extends React.Component<OptionsWidgetProps, OptionsWi
                 }
                 break;
             case InputId.Length:
-                if (!Number.isNaN(value)) {
+                if (!!value && !Number.isNaN(value)) {
                     this.props.updateMemoryState({
                         configuredReadArguments: {
                             ...this.props.configuredReadArguments,

--- a/src/webview/memory-webview-view.tsx
+++ b/src/webview/memory-webview-view.tsx
@@ -82,7 +82,7 @@ const MEMORY_DISPLAY_CONFIGURATION_DEFAULTS: MemoryDisplayConfiguration = {
     showRadixPrefix: true,
 };
 
-const DEFAULT_READ_ARGUMENTS: Required<ReadMemoryArguments> = {
+export const DEFAULT_READ_ARGUMENTS: Required<ReadMemoryArguments> = {
     memoryReference: '',
     offset: 0,
     count: 256,
@@ -249,12 +249,18 @@ class App extends React.Component<{}, MemoryAppState> {
         if (this.state.isFrozen) {
             return;
         }
-        this.setState(prev => ({ ...prev, isMemoryFetching: true }));
         const completeOptions = {
             memoryReference: partialOptions?.memoryReference || this.state.activeReadArguments.memoryReference,
             offset: partialOptions?.offset ?? this.state.activeReadArguments.offset,
             count: partialOptions?.count ?? this.state.activeReadArguments.count
         };
+
+        // Don't fetch memory if we have an incomplete memory reference
+        if (completeOptions.memoryReference === '') {
+            return;
+        }
+
+        this.setState(prev => ({ ...prev, isMemoryFetching: true }));
 
         try {
             const response = await messenger.sendRequest(readMemoryType, HOST_EXTENSION, completeOptions);

--- a/src/webview/memory-webview-view.tsx
+++ b/src/webview/memory-webview-view.tsx
@@ -28,7 +28,6 @@ import {
     logMessageType,
     MemoryOptions,
     memoryWrittenType,
-    ReadMemoryArguments,
     readMemoryType,
     readyType,
     resetMemoryViewSettingsType,
@@ -51,7 +50,7 @@ import { AddressHover } from './hovers/address-hover';
 import { DataHover } from './hovers/data-hover';
 import { hoverService, HoverService } from './hovers/hover-service';
 import { VariableHover } from './hovers/variable-hover';
-import { Decoration, MemoryDisplayConfiguration, MemoryState } from './utils/view-types';
+import { Decoration, DEFAULT_READ_ARGUMENTS, MemoryDisplayConfiguration, MemoryState } from './utils/view-types';
 import { variableDecorator } from './variables/variable-decorations';
 import { messenger } from './view-messenger';
 
@@ -80,12 +79,6 @@ const MEMORY_DISPLAY_CONFIGURATION_DEFAULTS: MemoryDisplayConfiguration = {
     addressPadding: 'Min',
     addressRadix: 16,
     showRadixPrefix: true,
-};
-
-export const DEFAULT_READ_ARGUMENTS: Required<ReadMemoryArguments> = {
-    memoryReference: '',
-    offset: 0,
-    count: 256,
 };
 
 class App extends React.Component<{}, MemoryAppState> {

--- a/src/webview/utils/view-types.ts
+++ b/src/webview/utils/view-types.ts
@@ -59,6 +59,12 @@ export interface MemoryState {
     isMemoryFetching: boolean;
 }
 
+export const DEFAULT_READ_ARGUMENTS: Required<ReadMemoryArguments> = {
+    memoryReference: '',
+    offset: 0,
+    count: 256,
+};
+
 export interface UpdateExecutor {
     fetchData(currentViewParameters: ReadMemoryArguments): Promise<void>;
 }


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/blob/main/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Avoid dispatching of a fetch memory request if there is not enough information available i.e no memory address is set.
Add validation for the default values of the memory address widget. => Prompts a validation error if the memory inspector has been openend for an empty/not set address 

Fixes #126

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Start a debug session and open the memory inspector via command palette
Observe that
- no memory fetch request is sent to the debug adapter (can be verified via Memory Inspector Output)
- A validation error is displayed for the memory address field because the memory is undefined

Once the user manually changes the address, the error disappears and memory is fetched normally.

https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/assets/2311075/6a630ee6-0ae8-4a34-81f5-ca87fd958a05


#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the contribution guidelines](https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/blob/main/CONTRIBUTING.md)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the code of conduct](https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/blob/main/CODE_OF_CONDUCT.md)
