### PR TITLE
Add Debug Context Selector

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
       "debug/variables/context": [
         {
           "command": "memory-inspector.show-variable",
-          "when": "canViewMemory && memory-inspector.canRead"
+          "when": "canViewMemory && memory-inspector.canReadVariable"
         },
         {
           "command": "memory-inspector.store-file",
@@ -152,7 +152,7 @@
       "view/item/context": [
         {
           "command": "memory-inspector.show-variable",
-          "when": "canViewMemory && memory-inspector.canRead"
+          "when": "canViewMemory && memory-inspector.canReadVariable"
         }
       ],
       "explorer/context": [

--- a/src/common/messaging.ts
+++ b/src/common/messaging.ts
@@ -47,6 +47,7 @@ export interface SessionContext {
     sessionId?: string;
     canRead: boolean;
     canWrite: boolean;
+    canReadVariable: boolean;
 }
 
 // Notifications

--- a/src/common/messaging.ts
+++ b/src/common/messaging.ts
@@ -38,6 +38,11 @@ export type StoreMemoryResult = void;
 export type ApplyMemoryArguments = URI | undefined;
 export type ApplyMemoryResult = MemoryOptions;
 
+export interface Context {
+    name: string;
+    id: number;
+}
+
 export interface SessionContext {
     sessionId?: string;
     canRead: boolean;
@@ -50,19 +55,22 @@ export const setMemoryViewSettingsType: NotificationType<Partial<MemoryViewSetti
 export const resetMemoryViewSettingsType: NotificationType<void> = { method: 'resetMemoryViewSettings' };
 export const setTitleType: NotificationType<string> = { method: 'setTitle' };
 export const memoryWrittenType: NotificationType<WrittenMemory> = { method: 'memoryWritten' };
-export const sessionContextChangedType: NotificationType<SessionContext> = { method: 'sessionContextChanged' };
+export const sessionContextChangedType: NotificationType<[SessionContext, Context?, Context[]?]> = { method: 'sessionContextChanged' };
 
 // Requests
 export const setOptionsType: RequestType<MemoryOptions, void> = { method: 'setOptions' };
 export const logMessageType: RequestType<string, void> = { method: 'logMessage' };
-export const readMemoryType: RequestType<ReadMemoryArguments, ReadMemoryResult> = { method: 'readMemory' };
-export const writeMemoryType: RequestType<WriteMemoryArguments, WriteMemoryResult> = { method: 'writeMemory' };
-export const getVariablesType: RequestType<ReadMemoryArguments, VariableRange[]> = { method: 'getVariables' };
-export const storeMemoryType: RequestType<StoreMemoryArguments, void> = { method: 'storeMemory' };
-export const applyMemoryType: RequestType<ApplyMemoryArguments, ApplyMemoryResult> = { method: 'applyMemory' };
+export const readMemoryType: RequestType<[ReadMemoryArguments, Context?], ReadMemoryResult> = { method: 'readMemory' };
+export const writeMemoryType: RequestType<[WriteMemoryArguments, Context?], WriteMemoryResult> = { method: 'writeMemory' };
+export const getVariablesType: RequestType<[ReadMemoryArguments, Context?], VariableRange[]> = { method: 'getVariables' };
+export const storeMemoryType: RequestType<[StoreMemoryArguments, Context?], void> = { method: 'storeMemory' };
+export const applyMemoryType: RequestType<[ApplyMemoryArguments, Context?], ApplyMemoryResult> = { method: 'applyMemory' };
 
 export const showAdvancedOptionsType: NotificationType<void> = { method: 'showAdvancedOptions' };
 export const getWebviewSelectionType: RequestType<void, WebviewSelection> = { method: 'getWebviewSelection' };
+
+export const getContextsType: RequestType<null, Context[]> = { method: 'getContexts' };
+export const getCurrentContextType: RequestType<null, Context> = { method: 'getCurrentContext' };
 
 export interface WebviewSelection {
     selectedCell?: {

--- a/src/entry-points/desktop/extension.ts
+++ b/src/entry-points/desktop/extension.ts
@@ -16,7 +16,9 @@
 
 import * as vscode from 'vscode';
 import { AdapterRegistry } from '../../plugin/adapter-registry/adapter-registry';
+import { AmalgamatorGdbVariableTransformer, AmalgamatorSessionManager } from '../../plugin/adapter-registry/amalgamator-gdb-tracker';
 import { CAdapter } from '../../plugin/adapter-registry/c-adapter';
+import { outputChannelLogger } from '../../plugin/logger';
 import { MemoryProvider } from '../../plugin/memory-provider';
 import { MemoryStorage } from '../../plugin/memory-storage';
 import { MemoryWebview } from '../../plugin/memory-webview-main';
@@ -27,6 +29,8 @@ export const activate = async (context: vscode.ExtensionContext): Promise<Adapte
     const memoryView = new MemoryWebview(context.extensionUri, memoryProvider);
     const memoryStorage = new MemoryStorage(memoryProvider);
     const cAdapter = new CAdapter(registry);
+    const debugTypes = ['amalgamator'];
+    registry.registerAdapter(new AmalgamatorSessionManager(AmalgamatorGdbVariableTransformer, outputChannelLogger, ...debugTypes), ...debugTypes);
 
     memoryProvider.activate(context);
     registry.activate(context);

--- a/src/plugin/adapter-registry/adapter-capabilities.ts
+++ b/src/plugin/adapter-registry/adapter-capabilities.ts
@@ -18,6 +18,7 @@ import { DebugProtocol } from '@vscode/debugprotocol';
 import * as vscode from 'vscode';
 import { isDebugRequest, isDebugResponse } from '../../common/debug-requests';
 import { VariableRange } from '../../common/memory-range';
+import { ReadMemoryArguments, ReadMemoryResult, WriteMemoryArguments, WriteMemoryResult } from '../../common/messaging';
 import { Logger } from '../logger';
 
 /** Represents capabilities that may be achieved with particular debug adapters but are not part of the DAP */
@@ -31,6 +32,8 @@ export interface AdapterCapabilities {
     /** Resolves the size of a given variable in bytes within the current context. */
     getSizeOfVariable?(session: vscode.DebugSession, variableName: string): Promise<bigint | undefined>;
     initializeAdapterTracker?(session: vscode.DebugSession): vscode.DebugAdapterTracker | undefined;
+    readMemory?(session: vscode.DebugSession, params: ReadMemoryArguments): Promise<ReadMemoryResult>;
+    writeMemory?(session: vscode.DebugSession, params: WriteMemoryArguments): Promise<WriteMemoryResult>;
 }
 
 export type WithChildren<Original> = Original & { children?: Array<WithChildren<DebugProtocol.Variable>> };
@@ -131,6 +134,10 @@ export class AdapterVariableTracker implements vscode.DebugAdapterTracker {
 
     /** Resolves the size of a given variable in bytes within the current context. */
     getSizeOfVariable?(variableName: string, session: vscode.DebugSession): Promise<bigint | undefined>;
+
+    readMemory?(session: vscode.DebugSession, params: ReadMemoryArguments): Promise<ReadMemoryResult>;
+
+    writeMemory?(session: vscode.DebugSession, params: WriteMemoryArguments): Promise<WriteMemoryResult>;
 }
 
 export class VariableTracker implements AdapterCapabilities {

--- a/src/plugin/adapter-registry/adapter-capabilities.ts
+++ b/src/plugin/adapter-registry/adapter-capabilities.ts
@@ -36,6 +36,7 @@ export interface AdapterCapabilities {
     writeMemory?(session: vscode.DebugSession, params: WriteMemoryArguments, context?: Context): Promise<WriteMemoryResult>;
     getContexts?(session: vscode.DebugSession): Promise<Context[]>;
     getCurrentContext?(session: vscode.DebugSession): Promise<Context | undefined>;
+    supportShowVariables?(session: vscode.DebugSession): boolean;
 }
 
 export type WithChildren<Original> = Original & { children?: Array<WithChildren<DebugProtocol.Variable>> };
@@ -143,6 +144,8 @@ export class AdapterVariableTracker implements vscode.DebugAdapterTracker {
 
     getContexts?(session: vscode.DebugSession): Promise<Context[]>;
     getCurrentContext?(session: vscode.DebugSession): Promise<Context | undefined>;
+
+    supportShowVariables?(session: vscode.DebugSession): boolean;
 }
 
 export class VariableTracker implements AdapterCapabilities {

--- a/src/plugin/adapter-registry/adapter-capabilities.ts
+++ b/src/plugin/adapter-registry/adapter-capabilities.ts
@@ -18,22 +18,24 @@ import { DebugProtocol } from '@vscode/debugprotocol';
 import * as vscode from 'vscode';
 import { isDebugRequest, isDebugResponse } from '../../common/debug-requests';
 import { VariableRange } from '../../common/memory-range';
-import { ReadMemoryArguments, ReadMemoryResult, WriteMemoryArguments, WriteMemoryResult } from '../../common/messaging';
+import { Context, ReadMemoryArguments, ReadMemoryResult, WriteMemoryArguments, WriteMemoryResult } from '../../common/messaging';
 import { Logger } from '../logger';
 
 /** Represents capabilities that may be achieved with particular debug adapters but are not part of the DAP */
 export interface AdapterCapabilities {
     /** Resolve variables known to the adapter to their locations. Fallback if {@link getResidents} is not present */
-    getVariables?(session: vscode.DebugSession): Promise<VariableRange[]>;
+    getVariables?(session: vscode.DebugSession, context?: Context): Promise<VariableRange[]>;
     /** Resolve symbols resident in the memory at the specified range. Will be preferred to {@link getVariables} if present. */
-    getResidents?(session: vscode.DebugSession, params: DebugProtocol.ReadMemoryArguments): Promise<VariableRange[]>;
+    getResidents?(session: vscode.DebugSession, params: DebugProtocol.ReadMemoryArguments, context?: Context): Promise<VariableRange[]>;
     /** Resolves the address of a given variable in bytes with the current context. */
-    getAddressOfVariable?(session: vscode.DebugSession, variableName: string): Promise<string | undefined>;
+    getAddressOfVariable?(session: vscode.DebugSession, variableName: string, context?: Context): Promise<string | undefined>;
     /** Resolves the size of a given variable in bytes within the current context. */
-    getSizeOfVariable?(session: vscode.DebugSession, variableName: string): Promise<bigint | undefined>;
+    getSizeOfVariable?(session: vscode.DebugSession, variableName: string, context?: Context): Promise<bigint | undefined>;
     initializeAdapterTracker?(session: vscode.DebugSession): vscode.DebugAdapterTracker | undefined;
-    readMemory?(session: vscode.DebugSession, params: ReadMemoryArguments): Promise<ReadMemoryResult>;
-    writeMemory?(session: vscode.DebugSession, params: WriteMemoryArguments): Promise<WriteMemoryResult>;
+    readMemory?(session: vscode.DebugSession, params: ReadMemoryArguments, context?: Context): Promise<ReadMemoryResult>;
+    writeMemory?(session: vscode.DebugSession, params: WriteMemoryArguments, context?: Context): Promise<WriteMemoryResult>;
+    getContexts?(session: vscode.DebugSession): Promise<Context[]>;
+    getCurrentContext?(session: vscode.DebugSession): Promise<Context | undefined>;
 }
 
 export type WithChildren<Original> = Original & { children?: Array<WithChildren<DebugProtocol.Variable>> };
@@ -104,14 +106,14 @@ export class AdapterVariableTracker implements vscode.DebugAdapterTracker {
         this.pendingMessages.clear();
     }
 
-    async getLocals(session: vscode.DebugSession): Promise<VariableRange[]> {
+    async getLocals(session: vscode.DebugSession, context?: Context): Promise<VariableRange[]> {
         this.logger.debug('Retrieving local variables in', session.name + ' Current variables:\n', this.variablesTree);
         if (this.currentFrame === undefined) { return []; }
         const maybeRanges = await Promise.all(Object.values(this.variablesTree).reduce<Array<Promise<VariableRange | undefined>>>((previous, parent) => {
             if (this.isDesiredVariable(parent) && parent.children?.length) {
                 this.logger.debug('Resolving children of', parent.name);
                 parent.children.forEach(child => {
-                    previous.push(this.variableToVariableRange(child, session));
+                    previous.push(this.variableToVariableRange(child, session, context));
                 });
             } else {
                 this.logger.debug('Ignoring', parent.name);
@@ -125,19 +127,22 @@ export class AdapterVariableTracker implements vscode.DebugAdapterTracker {
         return candidate.presentationHint !== 'registers' && candidate.name !== 'Registers';
     }
 
-    protected variableToVariableRange(_variable: DebugProtocol.Variable, _session: vscode.DebugSession): Promise<VariableRange | undefined> {
+    protected variableToVariableRange(_variable: DebugProtocol.Variable, _session: vscode.DebugSession, _context?: Context): Promise<VariableRange | undefined> {
         throw new Error('To be implemented by derived classes!');
     }
 
     /** Resolves the address of a given variable in bytes within the current context. */
-    getAddressOfVariable?(variableName: string, session: vscode.DebugSession): Promise<string | undefined>;
+    getAddressOfVariable?(variableName: string, session: vscode.DebugSession, context?: Context): Promise<string | undefined>;
 
     /** Resolves the size of a given variable in bytes within the current context. */
-    getSizeOfVariable?(variableName: string, session: vscode.DebugSession): Promise<bigint | undefined>;
+    getSizeOfVariable?(variableName: string, session: vscode.DebugSession, context?: Context): Promise<bigint | undefined>;
 
-    readMemory?(session: vscode.DebugSession, params: ReadMemoryArguments): Promise<ReadMemoryResult>;
+    readMemory?(session: vscode.DebugSession, params: ReadMemoryArguments, context?: Context): Promise<ReadMemoryResult>;
 
-    writeMemory?(session: vscode.DebugSession, params: WriteMemoryArguments): Promise<WriteMemoryResult>;
+    writeMemory?(session: vscode.DebugSession, params: WriteMemoryArguments, context?: Context): Promise<WriteMemoryResult>;
+
+    getContexts?(session: vscode.DebugSession): Promise<Context[]>;
+    getCurrentContext?(session: vscode.DebugSession): Promise<Context | undefined>;
 }
 
 export class VariableTracker implements AdapterCapabilities {
@@ -159,15 +164,15 @@ export class VariableTracker implements AdapterCapabilities {
         }
     }
 
-    async getVariables(session: vscode.DebugSession): Promise<VariableRange[]> {
-        return this.sessions.get(session.id)?.getLocals(session) ?? [];
+    async getVariables(session: vscode.DebugSession, context?: Context): Promise<VariableRange[]> {
+        return this.sessions.get(session.id)?.getLocals(session, context) ?? [];
     }
 
-    async getAddressOfVariable(session: vscode.DebugSession, variableName: string): Promise<string | undefined> {
-        return this.sessions.get(session.id)?.getAddressOfVariable?.(variableName, session);
+    async getAddressOfVariable(session: vscode.DebugSession, variableName: string, context?: Context): Promise<string | undefined> {
+        return this.sessions.get(session.id)?.getAddressOfVariable?.(variableName, session, context);
     }
 
-    async getSizeOfVariable(session: vscode.DebugSession, variableName: string): Promise<bigint | undefined> {
-        return this.sessions.get(session.id)?.getSizeOfVariable?.(variableName, session);
+    async getSizeOfVariable(session: vscode.DebugSession, variableName: string, context?: Context): Promise<bigint | undefined> {
+        return this.sessions.get(session.id)?.getSizeOfVariable?.(variableName, session, context);
     }
 }

--- a/src/plugin/adapter-registry/amalgamator-gdb-tracker.ts
+++ b/src/plugin/adapter-registry/amalgamator-gdb-tracker.ts
@@ -1,0 +1,110 @@
+/********************************************************************************
+ * Copyright (C) 2024 Ericsson, Arm and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { DebugProtocol } from '@vscode/debugprotocol';
+import * as vscode from 'vscode';
+import { Context, ReadMemoryArguments, ReadMemoryResult, WriteMemoryArguments, WriteMemoryResult } from '../../common/messaging';
+import { AdapterCapabilities, AdapterVariableTracker, VariableTracker } from './adapter-capabilities';
+
+// Copied from cdt-amalgamator [AmalgamatorSession.d.ts] file
+/**
+ * Response for our custom 'cdt-amalgamator/getChildDaps' request.
+ */
+export interface Contexts {
+    children?: Context[];
+}
+export interface GetContextsResponse extends DebugProtocol.Response {
+    body: Contexts;
+}
+export type GetContextsResult = GetContextsResponse['body'];
+
+export interface AmalgamatorReadArgs extends ReadMemoryArguments {
+    child: Context;
+}
+
+export class AmalgamatorSessionManager extends VariableTracker implements AdapterCapabilities {
+    async getContexts(session: vscode.DebugSession): Promise<Context[]> {
+        return this.sessions.get(session.id)?.getContexts?.(session) || [];
+    }
+
+    async readMemory(session: vscode.DebugSession, args: ReadMemoryArguments, context: Context): Promise<ReadMemoryResult> {
+        if (!context) {
+            vscode.window.showErrorMessage('Invalid context for Amalgamator. Select Context in Dropdown');
+            return {
+                address: args.memoryReference
+            };
+        }
+        return this.sessions.get(session.id)?.readMemory?.(session, args, context);
+    }
+
+    async writeMemory(session: vscode.DebugSession, args: WriteMemoryArguments, context: Context): Promise<WriteMemoryResult> {
+        return this.sessions.get(session.id)?.writeMemory?.(session, args, context);
+    }
+
+    async getCurrentContext(session: vscode.DebugSession): Promise<Context | undefined> {
+        return this.sessions.get(session.id)?.getCurrentContext?.(session);
+    }
+}
+
+export class AmalgamatorGdbVariableTransformer extends AdapterVariableTracker {
+    protected contexts?: Context[];
+    protected currentContext?: Context;
+
+    onWillReceiveMessage(message: unknown): void {
+        if (isStacktraceRequest(message)) {
+            if (typeof(message.arguments.threadId) !== 'undefined') {
+                this.currentContext = {
+                    id: message.arguments.threadId,
+                    name: message.arguments.threadId.toString()
+                };
+            } else {
+                this.logger.warn('Invalid ThreadID in stackTrace');
+                this.currentContext = undefined;
+            }
+        } else {
+            super.onWillReceiveMessage(message);
+        }
+    }
+
+    get frame(): number | undefined { return this.currentFrame; }
+
+    async getContexts(session: vscode.DebugSession): Promise<Context[]> {
+        if (!this.contexts) {
+            const contexts: GetContextsResult = (await session.customRequest('cdt-amalgamator/getChildDaps'));
+            this.contexts = contexts.children?.map(({ name, id }) => ({ name, id })) ?? [];
+        }
+        return Promise.resolve(this.contexts);
+    }
+
+    async getCurrentContext(_session: vscode.DebugSession): Promise<Context | undefined> {
+        return Promise.resolve(this.currentContext);
+    }
+
+    readMemory(session: vscode.DebugSession, args: ReadMemoryArguments, context: Context): Promise<ReadMemoryResult> {
+        const amalReadArgs: AmalgamatorReadArgs = { ...args, child: context };
+        return Promise.resolve(session.customRequest('cdt-amalgamator/readMemory', amalReadArgs));
+    }
+}
+
+export function isStacktraceRequest(message: unknown): message is DebugProtocol.StackTraceRequest {
+    const candidate = message as DebugProtocol.StackTraceRequest;
+    return !!candidate && candidate.command === 'stackTrace';
+}
+
+export function isStacktraceResponse(message: unknown): message is DebugProtocol.StackTraceResponse {
+    const candidate = message as DebugProtocol.StackTraceResponse;
+    return !!candidate && candidate.command === 'stackTrace' && Array.isArray(candidate.body.stackFrames);
+}

--- a/src/plugin/adapter-registry/amalgamator-gdb-tracker.ts
+++ b/src/plugin/adapter-registry/amalgamator-gdb-tracker.ts
@@ -57,6 +57,10 @@ export class AmalgamatorSessionManager extends VariableTracker implements Adapte
     async getCurrentContext(session: vscode.DebugSession): Promise<Context | undefined> {
         return this.sessions.get(session.id)?.getCurrentContext?.(session);
     }
+
+    supportShowVariables(_session: vscode.DebugSession): boolean {
+        return false;
+    }
 }
 
 export class AmalgamatorGdbVariableTransformer extends AdapterVariableTracker {

--- a/src/plugin/adapter-registry/amalgamator-gdb-tracker.ts
+++ b/src/plugin/adapter-registry/amalgamator-gdb-tracker.ts
@@ -90,7 +90,11 @@ export class AmalgamatorGdbVariableTransformer extends AdapterVariableTracker {
     }
 
     async getCurrentContext(_session: vscode.DebugSession): Promise<Context | undefined> {
-        return Promise.resolve(this.currentContext);
+        const curContext = this.contexts?.length ?
+            (this.contexts?.filter(context => context.id === this.currentContext?.id).shift() ??
+            this.currentContext) :
+            this.currentContext;
+        return Promise.resolve(curContext);
     }
 
     readMemory(session: vscode.DebugSession, args: ReadMemoryArguments, context: Context): Promise<ReadMemoryResult> {

--- a/src/plugin/memory-provider.ts
+++ b/src/plugin/memory-provider.ts
@@ -19,7 +19,7 @@ import * as vscode from 'vscode';
 import { isDebugEvent, isDebugRequest, isDebugResponse, sendRequest } from '../common/debug-requests';
 import { stringToBytesMemory } from '../common/memory';
 import { VariableRange, WrittenMemory } from '../common/memory-range';
-import { ReadMemoryResult, SessionContext, WriteMemoryResult } from '../common/messaging';
+import { Context, ReadMemoryResult, SessionContext, WriteMemoryResult } from '../common/messaging';
 import { AdapterRegistry } from './adapter-registry/adapter-registry';
 import * as manifest from './manifest';
 
@@ -143,14 +143,14 @@ export class MemoryProvider {
         return vscode.debug.activeDebugSession;
     }
 
-    public async readMemory(args: DebugProtocol.ReadMemoryArguments): Promise<ReadMemoryResult> {
+    public async readMemory(args: DebugProtocol.ReadMemoryArguments, context?: Context): Promise<ReadMemoryResult> {
         const session = this.assertCapability('supportsReadMemoryRequest', 'read memory');
         const handler = this.adapterRegistry?.getHandlerForSession(session.type);
-        if (handler?.readMemory) { return handler.readMemory(session, args); }
+        if (handler?.readMemory) { return handler.readMemory(session, args, context); }
         return sendRequest(session, 'readMemory', args);
     }
 
-    public async writeMemory(args: DebugProtocol.WriteMemoryArguments): Promise<WriteMemoryResult> {
+    public async writeMemory(args: DebugProtocol.WriteMemoryArguments, context?: Context): Promise<WriteMemoryResult> {
         const session = this.assertCapability('supportsWriteMemoryRequest', 'write memory');
         // Schedule a emit in case we don't retrieve a memory event
         this.scheduledOnDidMemoryWriteEvents[args.memoryReference] = response => {
@@ -162,7 +162,7 @@ export class MemoryProvider {
         };
         const handler = this.adapterRegistry?.getHandlerForSession(session.type);
         if (handler?.writeMemory) {
-            return handler.writeMemory(session, args).then(response => {
+            return handler.writeMemory(session, args, context).then(response => {
                 // The memory event is handled before we got here, if the scheduled event still exists, we need to handle it
                 this.scheduledOnDidMemoryWriteEvents[args.memoryReference]?.(response);
                 return response;
@@ -176,22 +176,34 @@ export class MemoryProvider {
         });
     }
 
-    public async getVariables(variableArguments: DebugProtocol.ReadMemoryArguments): Promise<VariableRange[]> {
+    public async getVariables(variableArguments: DebugProtocol.ReadMemoryArguments, context?: Context): Promise<VariableRange[]> {
         const session = this.assertActiveSession('get variables');
         const handler = this.adapterRegistry?.getHandlerForSession(session.type);
-        if (handler?.getResidents) { return handler.getResidents(session, variableArguments); }
-        return handler?.getVariables?.(session) ?? [];
+        if (handler?.getResidents) { return handler.getResidents(session, variableArguments, context); }
+        return handler?.getVariables?.(session, context) ?? [];
     }
 
-    public async getAddressOfVariable(variableName: string): Promise<string | undefined> {
+    public async getAddressOfVariable(variableName: string, context?: Context): Promise<string | undefined> {
         const session = this.assertActiveSession('get address of variable');
         const handler = this.adapterRegistry?.getHandlerForSession(session.type);
-        return handler?.getAddressOfVariable?.(session, variableName);
+        return handler?.getAddressOfVariable?.(session, variableName, context);
     }
 
-    public async getSizeOfVariable(variableName: string): Promise<bigint | undefined> {
+    public async getSizeOfVariable(variableName: string, context?: Context): Promise<bigint | undefined> {
         const session = this.assertActiveSession('get address of variable');
         const handler = this.adapterRegistry?.getHandlerForSession(session.type);
-        return handler?.getSizeOfVariable?.(session, variableName);
+        return handler?.getSizeOfVariable?.(session, variableName, context);
+    }
+
+    public async getContexts(): Promise<Context[]> {
+        const session = this.assertActiveSession('get list of debug Contexts');
+        const handler = this.adapterRegistry?.getHandlerForSession(session.type);
+        return handler?.getContexts?.(session) ?? [];
+    }
+
+    public async getCurrentContext(): Promise<Context|undefined> {
+        const session = this.assertActiveSession('get current debug Context');
+        const handler = this.adapterRegistry?.getHandlerForSession(session.type);
+        return handler?.getCurrentContext?.(session);
     }
 }

--- a/src/plugin/memory-storage.ts
+++ b/src/plugin/memory-storage.ts
@@ -23,7 +23,7 @@ import {
     validateCount, validateMemoryReference, validateOffset
 } from '../common/memory';
 import { toHexStringWithRadixMarker } from '../common/memory-range';
-import { ApplyMemoryArguments, ApplyMemoryResult, MemoryOptions, StoreMemoryArguments } from '../common/messaging';
+import { ApplyMemoryArguments, ApplyMemoryResult, Context, MemoryOptions, StoreMemoryArguments } from '../common/messaging';
 import { isWebviewContext } from '../common/webview-context';
 import { isVariablesContext } from './external-views';
 import * as manifest from './manifest';
@@ -60,7 +60,8 @@ export class MemoryStorage {
         );
     }
 
-    public async storeMemory(args?: StoreMemoryArguments): Promise<void> {
+    public async storeMemory(storeMemArgs?: [StoreMemoryArguments, Context?]): Promise<void> {
+        const [args, context] = storeMemArgs ?? [];
         const providedDefaultOptions = await this.storeArgsToOptions(args);
         const options = await this.getStoreMemoryOptions(providedDefaultOptions);
         if (!options) {
@@ -70,7 +71,7 @@ export class MemoryStorage {
 
         const { outputFile, ...readArgs } = options;
         try {
-            const memoryResponse = await this.memoryProvider.readMemory(readArgs);
+            const memoryResponse = await this.memoryProvider.readMemory(readArgs, context);
             const memory = createMemoryFromRead(memoryResponse);
             const memoryMap = new MemoryMap({ [Number(memory.address)]: memory.bytes });
             await vscode.workspace.fs.writeFile(outputFile, new TextEncoder().encode(memoryMap.asHexString()));
@@ -89,7 +90,7 @@ export class MemoryStorage {
         }
     }
 
-    protected async storeArgsToOptions(args?: StoreMemoryArguments): Promise<Partial<StoreMemoryOptions>> {
+    protected async storeArgsToOptions(args?: StoreMemoryArguments, context?: Context): Promise<Partial<StoreMemoryOptions>> {
         if (!args) {
             return {};
         }
@@ -99,8 +100,8 @@ export class MemoryStorage {
         if (isVariablesContext(args)) {
             try {
                 const variableName = args.variable.evaluateName ?? args.variable.name;
-                const count = await this.memoryProvider.getSizeOfVariable(variableName);
-                const memoryReference = args.variable.memoryReference ?? await this.memoryProvider.getAddressOfVariable(variableName);
+                const count = await this.memoryProvider.getSizeOfVariable(variableName, context);
+                const memoryReference = args.variable.memoryReference ?? await this.memoryProvider.getAddressOfVariable(variableName, context);
                 return { count: Number(count), memoryReference, offset: 0, proposedOutputName: variableName };
             } catch (error) {
                 // ignore, we are just using them as default values
@@ -169,7 +170,7 @@ export class MemoryStorage {
                 memoryReference = toHexStringWithRadixMarker(address);
                 count = memory.length;
                 const data = bytesToStringMemory(memory);
-                await this.memoryProvider.writeMemory({ memoryReference, data });
+                await this.memoryProvider.writeMemory({ memoryReference, data }, undefined);
             }
             await vscode.window.showInformationMessage(`Memory from '${vscode.workspace.asRelativePath(options.uri)}' applied.`);
             return { memoryReference, count, offset: 0 };

--- a/src/plugin/memory-webview-main.ts
+++ b/src/plugin/memory-webview-main.ts
@@ -263,8 +263,9 @@ export class MemoryWebview implements vscode.CustomReadonlyEditorProvider {
     }
 
     protected async setSessionContext(webviewParticipant: WebviewIdMessageParticipant, context: SessionContext): Promise<void> {
+        const contexts = await this.getContexts();  // Want to read this first.
         await this.messenger.sendRequest(sessionContextChangedType, webviewParticipant, [context,
-            await this.getCurrentContext(), await this.getContexts()]);
+            await this.getCurrentContext(), contexts]);
     }
 
     protected getMemoryViewSettings(messageParticipant: WebviewIdMessageParticipant, title: string): MemoryViewSettings {

--- a/src/webview/columns/data-column.tsx
+++ b/src/webview/columns/data-column.tsx
@@ -209,10 +209,10 @@ export class EditableDataColumnRow extends React.Component<EditableDataColumnRow
         if (originalData !== this.inputText.current.value) {
             const newMemoryValue = this.processData(this.inputText.current.value, this.state.editedRange);
             const converted = Buffer.from(newMemoryValue, 'hex').toString('base64');
-            await messenger.sendRequest(writeMemoryType, HOST_EXTENSION, {
+            await messenger.sendRequest(writeMemoryType, HOST_EXTENSION, [{
                 memoryReference: toHexStringWithRadixMarker(this.state.editedRange.startAddress),
                 data: converted
-            }).catch(() => { });
+            }, undefined]).catch(() => { });
         }
 
         this.disableEdit();

--- a/src/webview/components/memory-widget.tsx
+++ b/src/webview/components/memory-widget.tsx
@@ -17,7 +17,7 @@
 import React from 'react';
 import { WebviewIdMessageParticipant } from 'vscode-messenger-common';
 import { Memory } from '../../common/memory';
-import { WebviewSelection } from '../../common/messaging';
+import { Context, WebviewSelection } from '../../common/messaging';
 import { MemoryOptions, ReadMemoryArguments, SessionContext } from '../../common/messaging';
 import { ColumnStatus } from '../columns/column-contribution-service';
 import { HoverService } from '../hovers/hover-service';
@@ -48,6 +48,9 @@ interface MemoryWidgetProps extends MemoryDisplayConfiguration {
     fetchMemory(partialOptions?: MemoryOptions): Promise<void>;
     storeMemory(): void;
     applyMemory(): void;
+    contexts: Context[];
+    context?: Context;
+    setContext: (context: Context) => void;
 }
 
 interface MemoryWidgetState {
@@ -102,6 +105,9 @@ export class MemoryWidget extends React.Component<MemoryWidgetProps, MemoryWidge
                 isFrozen={this.props.isFrozen}
                 storeMemory={this.props.storeMemory}
                 applyMemory={this.props.applyMemory}
+                contexts={this.props.contexts}
+                context={this.props.context}
+                setContext={this.props.setContext}
             />
             <MemoryTable
                 ref={this.memoryTable}

--- a/src/webview/components/options-widget.tsx
+++ b/src/webview/components/options-widget.tsx
@@ -24,7 +24,7 @@ import { classNames } from 'primereact/utils';
 import React, { FocusEventHandler, KeyboardEvent, KeyboardEventHandler, MouseEventHandler, ReactNode } from 'react';
 import { validateCount, validateMemoryReference, validateOffset } from '../../common/memory';
 import { Endianness } from '../../common/memory-range';
-import { MemoryOptions, ReadMemoryArguments, SessionContext } from '../../common/messaging';
+import { Context, MemoryOptions, ReadMemoryArguments, SessionContext } from '../../common/messaging';
 import { tryToNumber } from '../../common/typescript';
 import { CONFIG_BYTES_PER_MAU_CHOICES, CONFIG_GROUPS_PER_ROW_CHOICES, CONFIG_MAUS_PER_GROUP_CHOICES } from '../../plugin/manifest';
 import { TableRenderOptions } from '../columns/column-contribution-service';
@@ -48,6 +48,9 @@ export interface OptionsWidgetProps
     isFrozen: boolean;
     storeMemory(): void;
     applyMemory(): void;
+    contexts: Context[];
+    context?: Context;
+    setContext: (debugContext: Context) => void;
 }
 
 interface OptionsWidgetState {
@@ -65,6 +68,7 @@ const enum InputId {
     AddressPadding = 'address-padding',
     AddressRadix = 'address-radix',
     ShowRadixPrefix = 'show-radix-prefix',
+    Contexts = 'debug-contexts'
 }
 
 interface OptionsForm {
@@ -126,6 +130,30 @@ export class OptionsWidget extends React.Component<OptionsWidgetProps, OptionsWi
             this.labelEditInput.current?.select();
         }
     }
+
+    private onContextDropdownChange = (e: DropdownChangeEvent) => {
+        const { setContext, contexts } = this.props;
+        setContext(contexts.filter(context => context.id === Number(e.value))[0]);
+    };
+
+    protected showContexts = () => {
+        if (this.props.contexts.length === 0) {
+            return undefined;
+        }
+        return (
+            <span className='pm-top-label'>
+                <label htmlFor={InputId.Contexts} className='p-inputtext-label'>
+                    Context
+                </label>
+                <Dropdown
+                    id={InputId.Contexts}
+                    value={this.props.context?.id}
+                    options={this.props.contexts}
+                    optionLabel="name"
+                    optionValue="id"
+                    onChange={this.onContextDropdownChange} />
+            </span>);
+    };
 
     override render(): React.ReactNode {
         this.formConfig.initialValues = this.optionsFormValues;
@@ -203,6 +231,7 @@ export class OptionsWidget extends React.Component<OptionsWidgetProps, OptionsWi
                     <Formik {...this.formConfig}>
                         {formik => (
                             <form onSubmit={formik.handleSubmit} className='form-options'>
+                                {this.showContexts()}
                                 <span className={'pm-top-label form-textfield form-texfield-long'}>
                                     <label htmlFor={InputId.Address} className={`p-inputtext-label ${readDisabled ? 'p-disabled' : ''}`} >
                                         Address

--- a/src/webview/memory-webview-view.tsx
+++ b/src/webview/memory-webview-view.tsx
@@ -71,7 +71,8 @@ export interface MemoryAppState extends MemoryState, MemoryDisplayConfiguration 
 
 const DEFAULT_SESSION_CONTEXT: SessionContext = {
     canRead: false,
-    canWrite: false
+    canWrite: false,
+    canReadVariable: false
 };
 
 const MEMORY_DISPLAY_CONFIGURATION_DEFAULTS: MemoryDisplayConfiguration = {

--- a/src/webview/variables/variable-decorations.ts
+++ b/src/webview/variables/variable-decorations.ts
@@ -48,7 +48,7 @@ export class VariableDecorator implements ColumnContribution, Decorator {
 
     async fetchData(currentViewParameters: ReadMemoryArguments): Promise<void> {
         if (!this.active || !currentViewParameters.memoryReference || !currentViewParameters.count) { return; }
-        const visibleVariables = (await messenger.sendRequest(getVariablesType, HOST_EXTENSION, currentViewParameters))
+        const visibleVariables = (await messenger.sendRequest(getVariablesType, HOST_EXTENSION, [currentViewParameters, undefined]))
             .map<BigIntVariableRange>(transmissible => {
                 const startAddress = BigInt(transmissible.startAddress);
                 return {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/blob/main/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
This PR addresses [Issue 67](https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/issues/67).
In a system with multiple children such as the `cdt-gdb-amalgamator`, the Memory Inspector needs a way to select the correct context (as the `cdt-gdb-vscode` Memory Browser does).

This PR has a dependency on `cdt-gdb-amalgamator` [PR 20](https://github.com/eclipse-cdt-cloud/cdt-amalgamator/pull/20) which puts the assignment of the Child IDs in the `cdt-gdb-amalgamator` instead of the Memory Inspector and also uses the `readMemory` since the data returned is in the correct format for Memory Inspector.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Run this branch of the `vscode-memory-inspector` with the mainline `cdt-gdb-vscode` and `cdt-gdb-adapter` along with the modified `cdt-gdb-amalgamator` in [PR 20](https://github.com/eclipse-cdt-cloud/cdt-amalgamator/pull/20).

Start the debugger as a Desktop Extension. In the newly launched VSCode, open the cdt-amalgamator/sampleWorkspace folder and place a breakpoint at the first instruction in empty1.c's main and empty2.c's main.  Start debugging with `Amalgamator Example` and you should run to the breakpoints. Open a new Memory Inspector with the Command Palette's `Memory: Show Memory Inspector` to open a new view. The dropdown should list both `proc1` and `proc2` listed in the Call Stack.

Select the appropriate `proc` by clicking on the corresponding main in the call stack. View the variable value in memory by typing:
`&local_in_main` into the `Address` textfield and pressing the `Go` button. Go back to the corresponding C file (empty1.c or empty2.c) and single step. The value of the `Local` variable in the `Variables` view will update. Open the `Memory` tab and the `Data` should have changed as well to match the `Variables` view.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the contribution guidelines](https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/blob/main/CONTRIBUTING.md)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the code of conduct](https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/blob/main/CODE_OF_CONDUCT.md)
