### PR TITLE
Enhances the context data of the context menu

### DIFF
--- a/src/common/webview-context.ts
+++ b/src/common/webview-context.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import { WebviewIdMessageParticipant } from 'vscode-messenger-common';
-import { VariableMetadata } from './memory-range';
+import { Endianness, VariableMetadata } from './memory-range';
 import { ReadMemoryArguments } from './messaging';
 
 export interface WebviewContext {
@@ -24,6 +24,8 @@ export interface WebviewContext {
     showAsciiColumn: boolean
     showVariablesColumn: boolean,
     showRadixPrefix: boolean,
+    endianness: Endianness,
+    bytesPerMau: number,
     activeReadArguments: Required<ReadMemoryArguments>
 }
 

--- a/src/webview/columns/data-column.tsx
+++ b/src/webview/columns/data-column.tsx
@@ -23,6 +23,7 @@ import { writeMemoryType } from '../../common/messaging';
 import type { MemorySizeOptions } from '../components/memory-table';
 import { decorationService } from '../decorations/decoration-service';
 import { Disposable, FullNodeAttributes } from '../utils/view-types';
+import { createGroupVscodeContext } from '../utils/vscode-contexts';
 import { characterWidthInContainer, elementInnerWidth } from '../utils/window';
 import { messenger } from '../view-messenger';
 import { ColumnContribution, TableRenderOptions } from './column-contribution-service';
@@ -90,6 +91,7 @@ export class EditableDataColumnRow extends React.Component<EditableDataColumnRow
             style={style}
             key={startAddress.toString(16)}
             onDoubleClick={this.setGroupEdit}
+            {...createGroupVscodeContext(startAddress, toOffset(startAddress, endAddress, this.props.options.bytesPerMau * 8))}
         >
             {maus}
         </span>;

--- a/src/webview/components/memory-widget.tsx
+++ b/src/webview/components/memory-widget.tsx
@@ -66,12 +66,15 @@ export class MemoryWidget extends React.Component<MemoryWidgetProps, MemoryWidge
 
     protected createVscodeContext(): VscodeContext {
         const visibleColumns = this.props.columns.filter(candidate => candidate.active).map(column => column.contribution.id);
+        const { messageParticipant, showRadixPrefix, endianness, bytesPerMau, activeReadArguments } = this.props;
         return createAppVscodeContext({
-            messageParticipant: this.props.messageParticipant,
-            showRadixPrefix: this.props.showRadixPrefix,
+            messageParticipant,
+            showRadixPrefix,
             showAsciiColumn: visibleColumns.includes('ascii'),
             showVariablesColumn: visibleColumns.includes('variables'),
-            activeReadArguments: this.props.activeReadArguments
+            endianness,
+            bytesPerMau,
+            activeReadArguments
         });
 
     }

--- a/src/webview/utils/vscode-contexts.ts
+++ b/src/webview/utils/vscode-contexts.ts
@@ -28,7 +28,7 @@ export interface VscodeContext {
 export type WebviewSection = 'optionsWidget' | 'advancedOptionsOverlay' | 'memoryTable';
 
 export function createVscodeContext<C extends {}>(context: C): VscodeContext {
-    return { 'data-vscode-context': JSON.stringify(includeFlatKeys(context)) };
+    return { 'data-vscode-context': JSON.stringify(includeFlatKeys(context), replacerForBigInt) };
 }
 
 function includeFlatKeys(src: object): Record<string, unknown> {
@@ -60,8 +60,19 @@ export function createAppVscodeContext(context: Omit<WebviewContext, 'webviewSec
     return createVscodeContext({ ...context, webviewSection: 'app', preventDefaultContextMenuItems: true });
 }
 
+export function createGroupVscodeContext(startAddress: BigInt, length: number): VscodeContext {
+    return createVscodeContext({ memoryData: { group: { startAddress, length } } });
+}
+
 export function createVariableVscodeContext(variable: BigIntVariableRange): VscodeContext {
     const { name, type, value, isPointer } = variable;
     return createVscodeContext({ variable: { name, type, value, isPointer } });
+}
+
+function replacerForBigInt(_: string, value: unknown): unknown {
+    if (typeof value === 'bigint') {
+        return `0x${value.toString(16)}`;
+    }
+    return value;
 }
 


### PR DESCRIPTION
#### What it does
Extends the VS Code context to augment the information available to context menus. In particular:

* Endianess and bytes per MAU
* Start address of memory data groups and their size (normalized to MAU size)

#### How to test
The easiest way to test this is to print out the arguments of a context menu command, e.g. in memory-webview-main.ts:112:
```typescript
vscode.commands.registerCommand(MemoryWebview.ToggleRadixPrefixCommandType, (ctx: WebviewContext) => {
        console.log('args', ctx);
        this.setMemoryViewSettings(ctx.messageParticipant, { showRadixPrefix: !ctx.showRadixPrefix });
}),
```
And observe the data in the `ctx` object. Here is a break down of what it currently contains.

<details>
  <summary>Context menu somewhere in the upper part of the memory inspector (now contains `endianness` and `bytesPerMau`)</summary>

```json
{
    "messageParticipant": {
        "type": "webview",
        "webviewId": "memory-inspector.memory_2"
    },
    "showRadixPrefix": true,
    "showAsciiColumn": false,
    "showVariablesColumn": true,
    "endianness": "Little Endian",
    "bytesPerMau": 1,
    "activeReadArguments": {
        "memoryReference": "0x20001c2c",
        "offset": 0,
        "count": 256
    },
    "webviewSection": "optionsWidget",
    "preventDefaultContextMenuItems": true,
    "memory-inspector.messageParticipant.type": "webview",
    "memory-inspector.messageParticipant.webviewId": "memory-inspector.memory_2",
    "memory-inspector.showRadixPrefix": true,
    "memory-inspector.showAsciiColumn": false,
    "memory-inspector.showVariablesColumn": true,
    "memory-inspector.endianness": "Little Endian",
    "memory-inspector.bytesPerMau": 1,
    "memory-inspector.activeReadArguments.memoryReference": "0x20001c2c",
    "memory-inspector.activeReadArguments.offset": 0,
    "memory-inspector.activeReadArguments.count": 256,
    "memory-inspector.webviewSection": "optionsWidget",
    "memory-inspector.preventDefaultContextMenuItems": true,
    "webview": "memory-inspector.memory"
}
```

</details>

<details>
  <summary>Context menu on a specific group in the memory data (now contains start and size of the group)</summary>

```json
{
    "messageParticipant": {
        "type": "webview",
        "webviewId": "memory-inspector.memory_2"
    },
    "showRadixPrefix": false,
    "showAsciiColumn": false,
    "showVariablesColumn": true,
    "endianness": "Little Endian",
    "bytesPerMau": 2,
    "activeReadArguments": {
        "memoryReference": "0x20001c2c",
        "offset": 0,
        "count": 256
    },
    "webviewSection": "memoryTable",
    "preventDefaultContextMenuItems": true,
    "memory-inspector.messageParticipant.type": "webview",
    "memory-inspector.messageParticipant.webviewId": "memory-inspector.memory_2",
    "memory-inspector.showRadixPrefix": false,
    "memory-inspector.showAsciiColumn": false,
    "memory-inspector.showVariablesColumn": true,
    "memory-inspector.endianness": "Little Endian",
    "memory-inspector.bytesPerMau": 2,
    "memory-inspector.activeReadArguments.memoryReference": "0x20001c2c",
    "memory-inspector.activeReadArguments.offset": 0,
    "memory-inspector.activeReadArguments.count": 256,
    "memory-inspector.webviewSection": "memoryTable",
    "memory-inspector.preventDefaultContextMenuItems": true,
    "column": "data",
    "memory-inspector.column": "data",
    "value": "000000000000aa810000000020001c90",
    "memoryData": {
        "group": {
            "startAddress": "0x20001c2c",
            "length": 4
        }
    },
    "memory-inspector.memoryData.group.startAddress": "0x20001c2c",
    "memory-inspector.memoryData.group.length": 4,
    "webview": "memory-inspector.memory"
}
```

</details>

<details>
  <summary>Context menu on a specific variable (already contained this information before this PR)</summary>

```json
{
    "messageParticipant": {
        "type": "webview",
        "webviewId": "memory-inspector.memory_2"
    },
    "showRadixPrefix": true,
    "showAsciiColumn": false,
    "showVariablesColumn": true,
    "endianness": "Little Endian",
    "bytesPerMau": 2,
    "activeReadArguments": {
        "memoryReference": "0x20001c2c",
        "offset": 0,
        "count": 256
    },
    "webviewSection": "memoryTable",
    "preventDefaultContextMenuItems": true,
    "memory-inspector.messageParticipant.type": "webview",
    "memory-inspector.messageParticipant.webviewId": "memory-inspector.memory_2",
    "memory-inspector.showRadixPrefix": true,
    "memory-inspector.showAsciiColumn": false,
    "memory-inspector.showVariablesColumn": true,
    "memory-inspector.endianness": "Little Endian",
    "memory-inspector.bytesPerMau": 2,
    "memory-inspector.activeReadArguments.memoryReference": "0x20001c2c",
    "memory-inspector.activeReadArguments.offset": 0,
    "memory-inspector.activeReadArguments.count": 256,
    "memory-inspector.webviewSection": "memoryTable",
    "memory-inspector.preventDefaultContextMenuItems": true,
    "column": "variables",
    "memory-inspector.column": "variables",
    "value": "arg",
    "variable": {
        "name": "arg",
        "type": "void*",
        "value": "(void*) 0x0",
        "isPointer": true
    },
    "memory-inspector.variable.name": "arg",
    "memory-inspector.variable.type": "void*",
    "memory-inspector.variable.value": "(void*) 0x0",
    "memory-inspector.variable.isPointer": true,
    "webview": "memory-inspector.memory"
}
```

</details>

#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the contribution guidelines](https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/blob/main/CONTRIBUTING.md)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the code of conduct](https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/blob/main/CODE_OF_CONDUCT.md)
