### PR TITLE
Fix import

### DIFF
--- a/src/common/webview-context.ts
+++ b/src/common/webview-context.ts
@@ -15,7 +15,8 @@
  ********************************************************************************/
 
 import { WebviewIdMessageParticipant } from 'vscode-messenger-common';
-import { Endianness, VariableMetadata } from './memory-range';
+import { Endianness } from './manifest';
+import { VariableMetadata } from './memory-range';
 import { ReadMemoryArguments } from './messaging';
 
 export interface WebviewContext {


### PR DESCRIPTION
#### What it does

Looks like the rebase of #135 causes a compile error. This change fixes the broken import.

#### How to test

As this just fixes the import, a green build should be enough. Locally I quickly tested the functionality again though.

#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the contribution guidelines](https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/blob/main/CONTRIBUTING.md)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the code of conduct](https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/blob/main/CODE_OF_CONDUCT.md)
