### PR TITLE
Introduce group-level selection and navigation for table

### DIFF
--- a/media/memory-table.css
+++ b/media/memory-table.css
@@ -27,8 +27,9 @@
   white-space: nowrap;
 }
 
-.memory-inspector-table .column-data .byte-group.editable:hover {
-  border-bottom: 1px dotted var(--vscode-editorHoverWidget-border);
+.p-datatable :focus-visible {
+  outline-style: dotted;
+  outline-offset: -1px;
 }
 
 /* == MoreMemorySelect == */
@@ -161,22 +162,60 @@
   color: var(--vscode-debugTokenExpression-name);
 }
 
-/* == Data Edit == */
+/* Cell Styles */
 
-.byte-group {
-  font-family: var(--vscode-editor-font-family);
-  margin-right: 2px;
-  padding: 0 1px; /* we use this padding to balance out the 2px that are needed for the editing */
+.p-datatable .p-datatable-tbody > tr > td[data-column="address"][role="cell"],
+.p-datatable .p-datatable-tbody > tr > td[data-column="ascii"][role="cell"] {
+  padding: 0;
 }
 
-.byte-group:last-child {
+.p-datatable .p-datatable-tbody > tr > td[data-column="data"][role="cell"],
+.p-datatable .p-datatable-tbody > tr > td[data-column="variables"][role="cell"] {
+  padding: 0 12px;
+  vertical-align: middle;
+}
+
+/* Group Styles */
+
+[role='group']:hover {
+  border-bottom: 0px;
+  color: var(--vscode-list-activeSelectionForeground);
+  outline: 1px solid var(--vscode-list-focusOutline);
+}
+
+[role='group'][data-group-selected='true'] {
+  background: var(--vscode-list-activeSelectionBackground);
+  color: var(--vscode-list-activeSelectionForeground);
+  outline: 1px solid var(--vscode-list-focusOutline);
+}
+
+[data-column="address"][role="group"],
+[data-column="ascii"][role="group"] {
+  padding: 4px 12px;
+  display: flex;
+  outline-offset: -1px;
+}
+
+[data-column="data"][role="group"],
+[data-column="variables"][role="group"] {
+  padding: 4px 1px;
+  line-height: 23.5px;
+  outline-offset: -1px;
+}
+
+/* Data Column */
+
+
+/* == Data Edit == */
+
+[data-column="data"][role="group"]:last-child {
   margin-right: 0px;
 }
 
-.byte-group:has(> .data-edit) {
+[data-column="data"][role="group"]:has(> .data-edit) {
   outline: 1px solid var(--vscode-inputOption-activeBorder);
-  outline-offset: 1px;
-  padding: 0px; /* editing takes two more pixels cause the input field will cut off the characters otherwise. */
+  padding-left: 0px; /* editing takes two more pixels cause the input field will cut off the characters otherwise. */
+  padding-right: 0px; /* editing takes two more pixels cause the input field will cut off the characters otherwise. */
 }
 
 .data-edit {
@@ -193,5 +232,11 @@
 .data-edit:enabled:focus {
   outline: none;
   border: none;
+  color: var(--vscode-list-activeSelectionForeground);
   text-indent: 1px;
+}
+
+.p-datatable .p-datatable-tbody > tr > td.p-highlight:has(>.selected) {
+  background: transparent;
+  outline: none;
 }

--- a/media/memory-table.css
+++ b/media/memory-table.css
@@ -179,13 +179,17 @@
 
 [role='group']:hover {
   border-bottom: 0px;
-  color: var(--vscode-list-activeSelectionForeground);
   outline: 1px solid var(--vscode-list-focusOutline);
 }
 
 [role='group'][data-group-selected='true'] {
   background: var(--vscode-list-activeSelectionBackground);
   color: var(--vscode-list-activeSelectionForeground);
+  outline: 1px solid var(--vscode-list-activeSelectionBackground);
+}
+
+[role='group']:focus-visible,
+[role='group']:focus {
   outline: 1px solid var(--vscode-list-focusOutline);
 }
 
@@ -197,7 +201,7 @@
 }
 
 [data-column="data"][role="group"],
-[data-column="variables"][role="group"] {
+[data-column="variables"][role="group"] {  
   padding: 4px 1px;
   line-height: 23.5px;
   outline-offset: -1px;
@@ -205,15 +209,15 @@
 
 /* Data Column */
 
+[data-column="data"][role="group"] {
+  padding: 4px 2px; /* left-padding should match text-indent of data-edit */
+}
 
 /* == Data Edit == */
 
-[data-column="data"][role="group"]:last-child {
-  margin-right: 0px;
-}
-
 [data-column="data"][role="group"]:has(> .data-edit) {
   outline: 1px solid var(--vscode-inputOption-activeBorder);
+  background: transparent;
   padding-left: 0px; /* editing takes two more pixels cause the input field will cut off the characters otherwise. */
   padding-right: 0px; /* editing takes two more pixels cause the input field will cut off the characters otherwise. */
 }
@@ -222,18 +226,18 @@
   padding: 0;
   outline: 0;
   border: none;
-  text-indent: 1px;
+  text-indent: 2px;
   min-height: unset;
   height: 2ex;
   background: unset;
   margin: 0;
+  color: var(--vscode-editor-foreground) !important;
 }
 
 .data-edit:enabled:focus {
   outline: none;
   border: none;
-  color: var(--vscode-list-activeSelectionForeground);
-  text-indent: 1px;
+  text-indent: 2px;
 }
 
 .p-datatable .p-datatable-tbody > tr > td.p-highlight:has(>.selected) {

--- a/media/variable-decorations.css
+++ b/media/variable-decorations.css
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2024 EclipseSource.
+ * Copyright (C) 2024 Ericsson and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,10 +14,31 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-@import "./theme/theme.css";
+ /* Color wheel of variable decorations with 5 non-HC colors */
+.variable-0 {
+    color: var(--vscode-terminal-ansiBlue);
+}
 
-@import "./root.css";
-@import "./multi-select.css";
-@import "./options-widget.css";
-@import "./memory-table.css";
-@import "./variable-decorations.css";
+.variable-1 {
+    color: var(--vscode-terminal-ansiGreen);
+}
+
+.variable-2 {
+    color: var(--vscode-terminal-ansiBrightRed);
+}
+
+.variable-3 {
+    color: var(--vscode-terminal-ansiYellow);
+}
+
+.variable-4 {
+    color: var(--vscode-terminal-ansiMagenta);
+}
+
+[role='group'][data-group-selected='true'] .variable-0,
+[role='group'][data-group-selected='true'] .variable-1,
+[role='group'][data-group-selected='true'] .variable-2,
+[role='group'][data-group-selected='true'] .variable-3,
+[role='group'][data-group-selected='true'] .variable-4 {
+   color: inherit;
+}

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "@vscode/codicons": "^0.0.32",
+    "deepmerge": "^4.3.1",
     "fast-deep-equal": "^3.1.3",
     "formik": "^2.4.5",
     "lodash": "^4.17.21",

--- a/src/common/os.ts
+++ b/src/common/os.ts
@@ -1,0 +1,33 @@
+/********************************************************************************
+ * Copyright (C) 2017 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+// from https://github.com/eclipse-theia/theia/blob/266fa0b2a9cf2649ed9b34c8b71b786806e787b4/packages/core/src/common/os.ts#L4
+
+function is(userAgent: string, platform: string): boolean {
+    if (typeof navigator !== 'undefined') {
+        if (navigator.userAgent && navigator.userAgent.indexOf(userAgent) >= 0) {
+            return true;
+        }
+    }
+    if (typeof process !== 'undefined') {
+        return (process.platform === platform);
+    }
+    return false;
+}
+
+export const isWindows = is('Windows', 'win32');
+export const isOSX = is('Mac', 'darwin');
+export const isLinux = !isWindows && !isOSX;

--- a/src/webview/columns/address-column.tsx
+++ b/src/webview/columns/address-column.tsx
@@ -15,9 +15,10 @@
  ********************************************************************************/
 
 import React, { ReactNode } from 'react';
-import { Memory } from '../../common/memory';
-import { BigIntMemoryRange, getAddressString, getRadixMarker } from '../../common/memory-range';
-import { ColumnContribution, ColumnFittingType, TableRenderOptions } from './column-contribution-service';
+import { getAddressString, getRadixMarker } from '../../common/memory-range';
+import { MemoryRowData } from '../components/memory-table';
+import { ColumnContribution, ColumnFittingType, ColumnRenderProps } from './column-contribution-service';
+import { createDefaultSelection, groupAttributes, SelectionProps } from './table-group';
 
 export class AddressColumn implements ColumnContribution {
     static ID = 'address';
@@ -28,10 +29,16 @@ export class AddressColumn implements ColumnContribution {
 
     fittingType: ColumnFittingType = 'content-width';
 
-    render(range: BigIntMemoryRange, _: Memory, options: TableRenderOptions): ReactNode {
-        return <span className='memory-start-address hoverable' data-column='address'>
-            {options.showRadixPrefix && <span className='radix-prefix'>{getRadixMarker(options.addressRadix)}</span>}
-            <span className='address'>{getAddressString(range.startAddress, options.addressRadix, options.effectiveAddressLength)}</span>
+    render(columnIndex: number, row: MemoryRowData, config: ColumnRenderProps): ReactNode {
+        const selectionProps: SelectionProps = {
+            createSelection: (event, position) => createDefaultSelection(event, position, AddressColumn.ID, row),
+            getSelection: () => config.selection,
+            setSelection: config.setSelection
+        };
+        const groupProps = groupAttributes({ columnIndex, rowIndex: row.rowIndex, groupIndex: 0, maxGroupIndex: 0 }, selectionProps);
+        return <span className='memory-start-address hoverable' data-column='address' {...groupProps}>
+            {config.tableConfig.showRadixPrefix && <span className='radix-prefix'>{getRadixMarker(config.tableConfig.addressRadix)}</span>}
+            <span className='address'>{getAddressString(row.startAddress, config.tableConfig.addressRadix, config.tableConfig.effectiveAddressLength)}</span>
         </span>;
     }
 }

--- a/src/webview/columns/column-contribution-service.ts
+++ b/src/webview/columns/column-contribution-service.ts
@@ -14,13 +14,22 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+import { ColumnPassThroughOptions } from 'primereact/column';
 import type * as React from 'react';
 import { Memory } from '../../common/memory';
-import { BigIntMemoryRange } from '../../common/memory-range';
 import { ReadMemoryArguments } from '../../common/messaging';
+import { MemoryRowData, MemoryTableSelection, MemoryTableState } from '../components/memory-table';
 import type { Disposable, MemoryState, SerializedTableRenderOptions, UpdateExecutor } from '../utils/view-types';
 
 export type ColumnFittingType = 'content-width';
+
+export interface ColumnRenderProps {
+    memory: Memory;
+    tableConfig: TableRenderOptions;
+    groupsPerRowToRender: number;
+    selection?: MemoryTableSelection;
+    setSelection: (selection?: MemoryTableSelection) => void;
+}
 
 export interface ColumnContribution {
     readonly id: string;
@@ -30,7 +39,8 @@ export interface ColumnContribution {
     fittingType?: ColumnFittingType;
     /** Sorted low to high. If omitted, sorted alphabetically by ID after all contributions with numbers. */
     priority?: number;
-    render(range: BigIntMemoryRange, memory: Memory, options: TableRenderOptions): React.ReactNode
+    pt?(columnIndex: number, state: MemoryTableState): ColumnPassThroughOptions;
+    render(columnIdx: number, row: MemoryRowData, config: ColumnRenderProps): React.ReactNode
     /** Called when fetching new memory or when activating the column. */
     fetchData?(currentViewParameters: ReadMemoryArguments): Promise<void>;
     /** Called when the user reveals the column */

--- a/src/webview/columns/data-column.tsx
+++ b/src/webview/columns/data-column.tsx
@@ -26,7 +26,7 @@ import type { MemoryRowData, MemorySizeOptions, MemoryTableSelection, MemoryTabl
 import { decorationService } from '../decorations/decoration-service';
 import { Disposable, FullNodeAttributes } from '../utils/view-types';
 import { createGroupVscodeContext } from '../utils/vscode-contexts';
-import { characterWidthInContainer, elementInnerWidth } from '../utils/window';
+import { characterWidthInContainer, elementInnerWidth, hasCtrlCmdMask } from '../utils/window';
 import { messenger } from '../view-messenger';
 import { AddressColumn } from './address-column';
 import { ColumnContribution, ColumnRenderProps } from './column-contribution-service';
@@ -262,7 +262,7 @@ export class EditableDataColumnRow extends React.Component<EditableDataColumnRow
                 break;
             }
             case 'v': {
-                if (event.ctrlKey) {
+                if (hasCtrlCmdMask(event)) {
                     // paste clipboard text and submit as change
                     const range = getAddressRange(event.currentTarget);
                     if (range) {

--- a/src/webview/columns/data-column.tsx
+++ b/src/webview/columns/data-column.tsx
@@ -14,99 +14,167 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+import { ColumnPassThroughOptions } from 'primereact/column';
 import { InputText } from 'primereact/inputtext';
 import * as React from 'react';
 import { HOST_EXTENSION } from 'vscode-messenger-common';
 import { Memory } from '../../common/memory';
 import { BigIntMemoryRange, isWithin, toHexStringWithRadixMarker, toOffset } from '../../common/memory-range';
 import { writeMemoryType } from '../../common/messaging';
-import type { MemorySizeOptions } from '../components/memory-table';
+import type { MemoryRowData, MemorySizeOptions, MemoryTableSelection, MemoryTableState } from '../components/memory-table';
 import { decorationService } from '../decorations/decoration-service';
 import { Disposable, FullNodeAttributes } from '../utils/view-types';
 import { createGroupVscodeContext } from '../utils/vscode-contexts';
 import { characterWidthInContainer, elementInnerWidth } from '../utils/window';
 import { messenger } from '../view-messenger';
-import { ColumnContribution, TableRenderOptions } from './column-contribution-service';
+import { AddressColumn } from './address-column';
+import { ColumnContribution, ColumnRenderProps } from './column-contribution-service';
+import {
+    findGroup,
+    getDefaultSearchContext,
+    getGroupPosition,
+    groupAttributes,
+    GroupPosition, handleGroupNavigation,
+    handleGroupSelection,
+    SelectionProps
+} from './table-group';
+
+export interface DataColumnSelection extends MemoryTableSelection {
+    selectedRange: BigIntMemoryRange;
+    editingRange?: BigIntMemoryRange;
+}
+
+export namespace DataColumnSelection {
+    export function is(selection?: MemoryTableSelection): selection is DataColumnSelection {
+        return !!selection && 'selectedRange' in selection;
+    }
+}
 
 export class DataColumn implements ColumnContribution {
+    static ID = 'data';
     static CLASS_NAME = 'column-data';
 
-    readonly id = 'data';
+    readonly id = DataColumn.ID;
     readonly className = DataColumn.CLASS_NAME;
     readonly label = 'Data';
     readonly priority = 1;
 
-    render(range: BigIntMemoryRange, memory: Memory, options: TableRenderOptions): React.ReactNode {
-        return <EditableDataColumnRow range={range} memory={memory} options={options} />;
+    protected focusGroupInstead(event: React.FocusEvent): void {
+        const previous = event.relatedTarget as HTMLOrSVGElement | null;
+        if (previous?.dataset['column'] === AddressColumn.ID) {
+            (event.target.firstElementChild as unknown as HTMLOrSVGElement)?.focus?.();
+            event.stopPropagation();
+        }
+        if (!!previous?.dataset['column']) {
+            (event.target.lastElementChild as unknown as HTMLOrSVGElement)?.focus?.();
+            event.stopPropagation();
+        }
+    }
+
+    pt(_columnIndex: number, _state: MemoryTableState): ColumnPassThroughOptions {
+        return {
+            root: {
+                onFocus: event => this.focusGroupInstead(event)
+            }
+        };
+    }
+
+    render(columnIndex: number, row: MemoryRowData, config: ColumnRenderProps): React.ReactNode {
+        return <EditableDataColumnRow columnIndex={columnIndex} row={row} config={config} />;
     }
 }
 
+export function getAddressRange(element: HTMLOrSVGElement): BigIntMemoryRange | undefined {
+    const start = element.dataset['rangeStart'];
+    const end = element.dataset['rangeEnd'];
+    if (!start || !end) { return undefined; }
+    return { startAddress: BigInt(start), endAddress: BigInt(end) };
+};
+
 export interface EditableDataColumnRowProps {
-    range: BigIntMemoryRange;
-    memory: Memory;
-    options: TableRenderOptions;
+    row: MemoryRowData;
+    columnIndex: number;
+    config: ColumnRenderProps;
 }
 
-export interface EditableDataColumnRowState {
-    editedRange?: BigIntMemoryRange;
-}
-
-export class EditableDataColumnRow extends React.Component<EditableDataColumnRowProps, EditableDataColumnRowState> {
-    state: EditableDataColumnRowState = {};
+export class EditableDataColumnRow extends React.Component<EditableDataColumnRowProps, {}> {
     protected inputText = React.createRef<HTMLInputElement>();
     protected toDisposeOnUnmount?: Disposable;
+
+    protected selectionProps: SelectionProps =
+        {
+            createSelection: (event, position) => this.createSelection(event, position),
+            getSelection: () => this.props.config.selection,
+            setSelection: this.props.config.setSelection
+        };
 
     render(): React.ReactNode {
         return this.renderGroups();
     }
 
     protected renderGroups(): React.ReactNode {
-        const { range, options, memory } = this.props;
+        const { row, config } = this.props;
         const groups = [];
         let maus: React.ReactNode[] = [];
-        let address = range.startAddress;
+        let address = row.startAddress;
         let groupStartAddress = address;
-        while (address < range.endAddress) {
-            maus.push(this.renderMau(memory, options, address));
+        let groupIdx = 0;
+        while (address < row.endAddress) {
+            maus.push(this.renderMau(config, address));
             const next = address + 1n;
-            if (maus.length % options.mausPerGroup === 0) {
-                this.applyEndianness(maus, options);
-                groups.push(this.renderGroup(maus, groupStartAddress, next));
+            if (maus.length % config.tableConfig.mausPerGroup === 0) {
+                this.applyEndianness(maus, config);
+                groups.push(this.renderGroup(maus, groupStartAddress, next, groupIdx++));
                 groupStartAddress = next;
                 maus = [];
             }
             address = next;
         }
-        if (maus.length) { groups.push(this.renderGroup(maus, groupStartAddress, range.endAddress)); }
+        if (maus.length) { groups.push(this.renderGroup(maus, groupStartAddress, row.endAddress, groupIdx)); }
         return groups;
     }
 
-    protected renderGroup(maus: React.ReactNode, startAddress: bigint, endAddress: bigint): React.ReactNode {
+    protected renderGroup(maus: React.ReactNode, startAddress: bigint, endAddress: bigint, idx: number): React.ReactNode {
+        const { config, row, columnIndex } = this.props;
+        const groupProps = groupAttributes({
+            rowIndex: row.rowIndex,
+            columnIndex: columnIndex,
+            groupIndex: idx,
+            maxGroupIndex: this.props.config.groupsPerRowToRender - 1
+        }, this.selectionProps);
         return <span
-            className='byte-group hoverable'
+            tabIndex={0}
+            className={['byte-group', 'hoverable'].join(' ')}
             data-column='data'
-            data-range={`${startAddress}-${endAddress}`}
+            {...groupProps}
+            data-range-start={startAddress}
+            data-range-end={endAddress}
             key={startAddress.toString(16)}
+            onKeyDown={this.onKeyDown}
             onDoubleClick={this.setGroupEdit}
-            {...createGroupVscodeContext(startAddress, toOffset(startAddress, endAddress, this.props.options.bytesPerMau * 8))}
+            {...createGroupVscodeContext(startAddress, toOffset(startAddress, endAddress, config.tableConfig.bytesPerMau * 8))}
         >
             {maus}
         </span>;
     }
 
-    protected renderMau(memory: Memory, options: TableRenderOptions, currentAddress: bigint): React.ReactNode {
-        if (currentAddress === this.state.editedRange?.startAddress) {
-            return this.renderEditingGroup(this.state.editedRange);
-        } else if (this.state.editedRange && isWithin(currentAddress, this.state.editedRange)) {
-            return;
+    protected renderMau(props: ColumnRenderProps, currentAddress: bigint): React.ReactNode {
+        if (DataColumnSelection.is(props.selection)) {
+            if (currentAddress === props.selection.editingRange?.startAddress) {
+                // render editable text field
+                return this.renderEditingGroup(props.selection.editingRange);
+            } else if (props.selection.editingRange && isWithin(currentAddress, props.selection.editingRange)) {
+                // covered by the editable text field
+                return;
+            }
         }
-        const initialOffset = toOffset(memory.address, currentAddress, options.bytesPerMau * 8);
-        const finalOffset = initialOffset + options.bytesPerMau;
+        const initialOffset = toOffset(props.memory.address, currentAddress, props.tableConfig.bytesPerMau * 8);
+        const finalOffset = initialOffset + props.tableConfig.bytesPerMau;
         const bytes: React.ReactNode[] = [];
         for (let i = initialOffset; i < finalOffset; i++) {
-            bytes.push(this.renderEightBits(memory, currentAddress, i));
+            bytes.push(this.renderEightBits(props.memory, currentAddress, i));
         }
-        this.applyEndianness(bytes, options);
+        this.applyEndianness(bytes, props);
         return <span className='single-mau' data-address={currentAddress.toString()} key={currentAddress.toString(16)}>{bytes}</span>;
     }
 
@@ -131,9 +199,9 @@ export class EditableDataColumnRow extends React.Component<EditableDataColumnRow
         };
     }
 
-    protected applyEndianness<T>(group: T[], options: TableRenderOptions): T[] {
+    protected applyEndianness<T>(group: T[], options: ColumnRenderProps): T[] {
         // Assume data from the DAP comes in Big Endian so we need to revert the order if we use Little Endian
-        return options.endianness === 'Big Endian' ? group : group.reverse();
+        return options.tableConfig.endianness === 'Big Endian' ? group : group.reverse();
     }
 
     protected renderEditingGroup(editedRange: BigIntMemoryRange): React.ReactNode {
@@ -150,72 +218,119 @@ export class EditableDataColumnRow extends React.Component<EditableDataColumnRow
             maxLength={defaultValue.length}
             defaultValue={defaultValue}
             onBlur={this.onBlur}
-            onKeyDown={this.onKeyDown}
+            onKeyDown={this.onEditKeyDown}
             autoFocus
             style={style}
         />;
     }
 
     protected createEditingGroupDefaultValue(editedRange: BigIntMemoryRange): string {
-        const bitsPerMau = this.props.options.bytesPerMau * 8;
-        const startOffset = toOffset(this.props.memory.address, editedRange.startAddress, bitsPerMau);
+        const bitsPerMau = this.props.config.tableConfig.bytesPerMau * 8;
+
+        const startOffset = toOffset(this.props.config.memory.address, editedRange.startAddress, bitsPerMau);
         const numBytes = toOffset(editedRange.startAddress, editedRange.endAddress, bitsPerMau);
 
-        const area = Array.from(this.props.memory.bytes.slice(startOffset, startOffset + numBytes));
-        this.applyEndianness(area, this.props.options);
+        const area = Array.from(this.props.config.memory.bytes.slice(startOffset, startOffset + numBytes));
+        this.applyEndianness(area, this.props.config);
 
         return area.map(byte => byte.toString(16).padStart(2, '0')).join('');
     }
 
-    protected onBlur: React.FocusEventHandler<HTMLInputElement> = () => {
-        this.submitChanges();
+    protected onBlur: React.FocusEventHandler<HTMLInputElement> = event => {
+        this.submitChanges(event);
     };
 
     protected onKeyDown: React.KeyboardEventHandler<HTMLInputElement> = event => {
         switch (event.key) {
+            case ' ': {
+                this.setGroupEdit(event);
+                break;
+            }
+        }
+        handleGroupNavigation(event);
+        handleGroupSelection(event, this.selectionProps);
+        event.stopPropagation();
+    };
+
+    protected onEditKeyDown: React.KeyboardEventHandler<HTMLInputElement> = event => {
+        switch (event.key) {
             case 'Escape': {
-                this.disableEdit();
+                this.disableEdit(event);
                 break;
             }
             case 'Enter': {
-                this.submitChanges();
+                this.submitChanges(event);
+                break;
             }
         }
         event.stopPropagation();
     };
 
-    protected setGroupEdit: React.MouseEventHandler<HTMLSpanElement> = event => {
+    protected setGroupEdit = (event: React.MouseEvent<HTMLSpanElement> | React.KeyboardEvent<HTMLSpanElement>) => {
         event.stopPropagation();
-        const range = event.currentTarget.dataset.range;
-        if (!range) { return; }
-        const [startAddress, endAddress] = range.split('-').map(BigInt);
-        this.setState({ editedRange: { startAddress, endAddress } });
+        const position = getGroupPosition(event.currentTarget);
+        if (!position) {
+            return;
+        }
+        const selection = this.createSelection(event, position);
+        if (selection) {
+            selection.editingRange = selection.selectedRange;
+            this.props.config.setSelection(selection);
+        }
     };
 
-    protected disableEdit(): void {
-        this.setState({ editedRange: undefined });
+    protected createSelection(event: React.BaseSyntheticEvent, position: GroupPosition): DataColumnSelection | undefined {
+        const range = getAddressRange(event.currentTarget);
+        if (!position || !range) {
+            return undefined;
+        }
+        return {
+            row: this.props.row,
+            column: { columnIndex: position.columnIndex, id: DataColumn.ID },
+            group: { groupIndex: position.groupIndex },
+            textContent: event.currentTarget.textContent ?? event.currentTarget.innerText,
+            selectedRange: range,
+            editingRange: undefined,
+        };
     }
 
-    protected async submitChanges(): Promise<void> {
-        if (!this.inputText.current || !this.state.editedRange) { return; }
+    protected disableEdit(event: React.BaseSyntheticEvent): void {
+        const selection = this.props.config.selection;
+        if (DataColumnSelection.is(selection)) {
+            selection.editingRange = undefined;
+            this.props.config.setSelection({ ...selection });
+        }
+        // restore focus
+        const parent = event.currentTarget.parentElement;
+        if (parent) {
+            const position = getGroupPosition(parent);
+            if (position) {
+                const context = getDefaultSearchContext(parent);
+                setTimeout(() => findGroup<HTMLElement>(position, context)?.focus());
+            }
+        }
+    }
 
-        const originalData = this.createEditingGroupDefaultValue(this.state.editedRange);
+    protected async submitChanges(event: React.BaseSyntheticEvent): Promise<void> {
+        if (!this.inputText.current || !DataColumnSelection.is(this.props.config.selection) || !this.props.config.selection.editingRange) { return; }
+
+        const originalData = this.createEditingGroupDefaultValue(this.props.config.selection.editingRange);
         if (originalData !== this.inputText.current.value) {
-            const newMemoryValue = this.processData(this.inputText.current.value, this.state.editedRange);
+            const newMemoryValue = this.processData(this.inputText.current.value, this.props.config.selection.editingRange);
             const converted = Buffer.from(newMemoryValue, 'hex').toString('base64');
             await messenger.sendRequest(writeMemoryType, HOST_EXTENSION, {
-                memoryReference: toHexStringWithRadixMarker(this.state.editedRange.startAddress),
+                memoryReference: toHexStringWithRadixMarker(this.props.config.selection.editingRange.startAddress),
                 data: converted
             }).catch(() => { });
         }
 
-        this.disableEdit();
+        this.disableEdit(event);
     }
 
     protected processData(data: string, editedRange: BigIntMemoryRange): string {
-        const characters = toOffset(editedRange.startAddress, editedRange.endAddress, this.props.options.bytesPerMau * 8) * 2;
+        const characters = toOffset(editedRange.startAddress, editedRange.endAddress, this.props.config.tableConfig.bytesPerMau * 8) * 2;
         // Revert Endianness
-        if (this.props.options.endianness === 'Little Endian') {
+        if (this.props.config.tableConfig.endianness === 'Little Endian') {
             const chunks = data.padStart(characters, '0').match(/.{2}/g) || [];
             return chunks.reverse().join('');
         }

--- a/src/webview/columns/table-group.tsx
+++ b/src/webview/columns/table-group.tsx
@@ -17,6 +17,7 @@
 
 import { DOMAttributes, HTMLAttributes } from 'react';
 import { MemoryRowData, MemoryTableSelection } from '../components/memory-table';
+import { hasCtrlCmdMask } from '../utils/window';
 
 export interface GroupPosition {
     columnIndex: number;
@@ -117,13 +118,13 @@ export function handleGroupNavigation<T extends HTMLElement>(event: React.Keyboa
             targetGroup = getGroupInPreviousRow(currentGroup);
             break;
         case 'c': {
-            if (event.ctrlKey) {
+            if (hasCtrlCmdMask(event)) {
                 handleCopy(event);
             }
             break;
         }
         case 'x': {
-            if (event.ctrlKey) {
+            if (hasCtrlCmdMask(event)) {
                 handleCut(event);
             }
             break;
@@ -237,7 +238,7 @@ export function toggleSelection<T extends HTMLElement>(event: React.MouseEvent<T
     const currentSelection = props.getSelection();
     if (isGroupSelected(position, currentSelection)) {
         // group is already selected
-        if (event.ctrlKey) {
+        if (hasCtrlCmdMask(event)) {
             // deselect
             props.setSelection();
         }

--- a/src/webview/columns/table-group.tsx
+++ b/src/webview/columns/table-group.tsx
@@ -1,0 +1,269 @@
+/********************************************************************************
+ * Copyright (C) 2024 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { DOMAttributes, HTMLAttributes } from 'react';
+import { MemoryRowData, MemoryTableSelection } from '../components/memory-table';
+
+export interface GroupPosition {
+    columnIndex: number;
+    rowIndex: number;
+    groupIndex: number;
+    maxGroupIndex: number;
+}
+
+export namespace GroupPosition {
+    export namespace Attributes {
+        export const ColumnIndex = 'data-column-index';
+        export const RowIndex = 'data-row-index';
+        export const GroupIndex = 'data-group-index';
+        export const MaxGroupIndex = 'data-max-group-index';
+        export const GroupSelected = 'data-group-selected';
+    }
+
+    export namespace DataSet {
+        export const ColumnIndex = 'columnIndex';
+        export const RowIndex = 'rowIndex';
+        export const GroupIndex = 'groupIndex';
+        export const MaxGroupIndex = 'maxGroupIndex';
+        export const GroupSelected = 'groupSelected';
+    }
+}
+
+export interface GroupPositionHTMLAttributes {
+    [GroupPosition.Attributes.ColumnIndex]?: number | undefined;
+    [GroupPosition.Attributes.RowIndex]?: number | undefined;
+    [GroupPosition.Attributes.GroupIndex]?: number | undefined;
+    [GroupPosition.Attributes.MaxGroupIndex]?: number | undefined;
+    [GroupPosition.Attributes.GroupSelected]?: boolean | undefined;
+}
+
+export interface GroupDOMStringMap extends DOMStringMap {
+    [GroupPosition.DataSet.ColumnIndex]: string | undefined;
+    [GroupPosition.DataSet.RowIndex]: string | undefined;
+    [GroupPosition.DataSet.GroupIndex]: string | undefined;
+    [GroupPosition.DataSet.MaxGroupIndex]: string | undefined;
+    [GroupPosition.DataSet.GroupSelected]: string | undefined;
+}
+
+export function groupAttributes<T extends HTMLElement>(position: GroupPosition, selection?: SelectionProps): HTMLAttributes<T> & DOMAttributes<T> & Record<string, unknown> {
+    return {
+        role: 'group',
+        tabIndex: 0,
+        onKeyDown: event => handleGroupNavigation(event) || selection && handleGroupSelection(event, selection),
+        onClick: event => selection && handleGroupSelection(event, selection),
+        onCopy: handleCopy,
+        onCut: handleCut,
+        [GroupPosition.Attributes.ColumnIndex]: position.columnIndex,
+        [GroupPosition.Attributes.RowIndex]: position.rowIndex,
+        [GroupPosition.Attributes.GroupIndex]: position.groupIndex,
+        [GroupPosition.Attributes.MaxGroupIndex]: position.maxGroupIndex,
+        [GroupPosition.Attributes.GroupSelected]: isGroupSelected(position, selection?.getSelection())
+    };
+}
+
+export function isGroupSelected(position: GroupPosition, selection?: MemoryTableSelection): boolean {
+    return selection?.column.columnIndex === position.columnIndex
+        && selection?.row.rowIndex === position.rowIndex
+        && selection?.group.groupIndex === position.groupIndex;
+}
+
+export function getGroupPosition(element: Element): GroupPosition | undefined {
+    const data = (element as unknown as HTMLOrSVGElement).dataset as GroupDOMStringMap;
+    const columnIndex = data.columnIndex;
+    const rowIndex = data.rowIndex;
+    const groupIndex = data.groupIndex;
+    const maxGroupIndex = data.maxGroupIndex;
+    if (!columnIndex || !rowIndex || !groupIndex) { return undefined; }
+    return { columnIndex: Number(columnIndex), rowIndex: Number(rowIndex), groupIndex: Number(groupIndex), maxGroupIndex: Number(maxGroupIndex) };
+}
+
+export function findGroup<T extends Element>(position: GroupPosition, element?: Element | null): T | undefined {
+    const context = element ?? document.documentElement;
+    // eslint-disable-next-line max-len
+    const group = context.querySelector<T>(`[${GroupPosition.Attributes.ColumnIndex}="${position.columnIndex}"][${GroupPosition.Attributes.RowIndex}="${position.rowIndex}"][${GroupPosition.Attributes.GroupIndex}="${position.groupIndex}"]`);
+    return !group ? undefined : group;
+}
+
+export function handleGroupNavigation<T extends HTMLElement>(event: React.KeyboardEvent<T>): boolean {
+    switch (event.key) {
+        case 'ArrowRight': {
+            const rightGroup = findRightGroup<HTMLElement>(event.currentTarget);
+            if (rightGroup) {
+                rightGroup.focus();
+                event.preventDefault();
+                event.stopPropagation();
+                return true;
+            }
+            break;
+        }
+        case 'ArrowLeft': {
+            const leftGroup = findLeftGroup<HTMLElement>(event.currentTarget);
+            if (leftGroup) {
+                leftGroup?.focus?.();
+                event.preventDefault();
+                event.stopPropagation();
+                return true;
+            }
+            break;
+        }
+        case 'ArrowUp': {
+            const upGroup = findUpGroup<HTMLElement>(event.currentTarget);
+            if (upGroup) {
+                upGroup?.focus?.();
+                event.preventDefault();
+                event.stopPropagation();
+                return true;
+            }
+            break;
+        }
+        case 'ArrowDown': {
+            const downGroup = findDownGroup<HTMLElement>(event.currentTarget);
+            if (downGroup) {
+                downGroup?.focus?.();
+                event.preventDefault();
+                event.stopPropagation();
+                return true;
+            }
+            break;
+        }
+        case 'c': {
+            if (event.ctrlKey) {
+                handleCopy(event);
+            }
+            break;
+        }
+        case 'x': {
+            if (event.ctrlKey) {
+                handleCut(event);
+            }
+            break;
+        }
+    }
+    return false;
+}
+
+export function getDefaultSearchContext(element: Element): Element | null {
+    return element.closest('p-datatable-tbody');
+}
+
+export function findLeftGroup<T extends Element>(element: Element, searchContext = getDefaultSearchContext(element)): T | undefined {
+    const position = getGroupPosition(element);
+    if (!position) {
+        return undefined;
+    }
+    if (position.columnIndex === 0 && position.groupIndex === 0) {
+        // we are already most left
+        return undefined;
+    }
+    if (position.groupIndex === 0) {
+        // we need to jump to the end of the previous column
+        // so we search for the first group which has the necessary information
+        const firstGroup = findGroup<T>({ ...position, columnIndex: position.columnIndex - 1, groupIndex: 0 }, searchContext);
+        if (firstGroup) {
+            const firstGroupPosition = getGroupPosition(firstGroup);
+            if (firstGroupPosition?.maxGroupIndex !== undefined && firstGroupPosition.maxGroupIndex !== position?.groupIndex) {
+                return findGroup<T>({ ...position, columnIndex: position.columnIndex - 1, groupIndex: firstGroupPosition.maxGroupIndex }, searchContext);
+            }
+        }
+        return firstGroup;
+    } else {
+        return findGroup<T>({ ...position, groupIndex: position.groupIndex - 1 }, searchContext);
+    }
+}
+
+export function findRightGroup<T extends Element>(element: Element, searchContext = getDefaultSearchContext(element)): T | undefined {
+    const position = getGroupPosition(element);
+    if (!position) {
+        return undefined;
+    }
+    const nextGroup = findGroup<T>({ ...position, groupIndex: position.groupIndex + 1 }, searchContext);
+    if (nextGroup) {
+        return nextGroup;
+    }
+    // we try to jump to the start of the next column
+    return findGroup<T>({ ...position, columnIndex: position.columnIndex + 1, groupIndex: 0 }, searchContext);
+}
+
+export function findUpGroup<T extends Element>(element: Element, searchContext = getDefaultSearchContext(element)): T | undefined {
+    const position = getGroupPosition(element);
+    return position ? findGroup<T>({ ...position, rowIndex: position.rowIndex - 1 }, searchContext) : undefined;
+}
+
+export function findDownGroup<T extends Element>(element: Element, searchContext = getDefaultSearchContext(element)): T | undefined {
+    const position = getGroupPosition(element);
+    return position ? findGroup<T>({ ...position, rowIndex: position.rowIndex + 1 }, searchContext) : undefined;
+}
+
+export interface SelectionProps {
+    createSelection<T extends HTMLElement>(event: React.MouseEvent<T> | React.KeyboardEvent<T>, position: GroupPosition): MemoryTableSelection | undefined;
+    getSelection(): MemoryTableSelection | undefined;
+    setSelection(selection?: MemoryTableSelection): void;
+}
+
+export function createDefaultSelection(event: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>, position: GroupPosition,
+    columnId: string, row: MemoryRowData): MemoryTableSelection {
+    return {
+        row,
+        column: { columnIndex: position.columnIndex, id: columnId },
+        group: { groupIndex: position.groupIndex },
+        textContent: event.currentTarget.textContent ?? event.currentTarget.innerText
+    };
+}
+
+function handleCopy(event: React.ClipboardEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>): void {
+    event.preventDefault();
+    const textSelection = window.getSelection()?.toString();
+    if (textSelection) {
+        navigator.clipboard.writeText(textSelection);
+    } else if (event.currentTarget.textContent) {
+        navigator.clipboard.writeText(event.currentTarget.textContent);
+    } else {
+        navigator.clipboard.writeText(event.currentTarget.innerText);
+    }
+};
+
+function handleCut(event: React.ClipboardEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>): void {
+    handleCopy(event);
+}
+
+export function handleGroupSelection<T extends HTMLElement>(event: React.KeyboardEvent<T> | React.MouseEvent<T>, props: SelectionProps): boolean {
+    if (!('key' in event) || event.key === 'Enter') {
+        // mouse event or ENTER key event
+        return toggleSelection(event, props);
+    }
+    return false;
+}
+
+export function toggleSelection<T extends HTMLElement>(event: React.MouseEvent<T> | React.KeyboardEvent<T>, props: SelectionProps): boolean {
+    const position = getGroupPosition(event.currentTarget);
+    if (!position) {
+        return false;
+    }
+    const currentSelection = props.getSelection();
+    if (isGroupSelected(position, currentSelection)) {
+        // group is already selected
+        if (event.ctrlKey) {
+            // deselect
+            props.setSelection();
+        }
+    } else {
+        props.setSelection(props.createSelection(event, position));
+    }
+    event.stopPropagation();
+    event.preventDefault();
+    return true;
+};
+

--- a/src/webview/decorations/decoration-service.ts
+++ b/src/webview/decorations/decoration-service.ts
@@ -73,16 +73,23 @@ class DecorationService {
                 if (index === terminiInOrder.length - 1) { return; }
                 const decoration: Decoration = {
                     range: { startAddress: terminus, endAddress: terminiInOrder[index + 1] },
-                    style: {}
+                    style: {},
+                    classNames: []
                 };
                 decorations.push(decoration);
                 currentSubDecorations.forEach((subDecoration, subDecorationIndex) => {
                     switch (determineRelationship(terminus, subDecoration?.range)) {
-                        case RangeRelationship.Within: Object.assign(decoration.style, subDecoration?.style);
+                        case RangeRelationship.Within: {
+                            Object.assign(decoration.style, subDecoration?.style);
+                            Object.assign(decoration.classNames, subDecoration?.classNames);
+                        }
                             break;
                         case RangeRelationship.Past: {
                             const newSubDecoration = currentSubDecorations[subDecorationIndex] = contributions[subDecorationIndex].next().value;
-                            if (determineRelationship(terminus, newSubDecoration.range) === RangeRelationship.Within) { Object.assign(decoration.style, newSubDecoration.style); }
+                            if (determineRelationship(terminus, newSubDecoration.range) === RangeRelationship.Within) {
+                                Object.assign(decoration.style, newSubDecoration.style);
+                                Object.assign(decoration.classNames, subDecoration?.classNames);
+                            }
                         }
                     }
                 });

--- a/src/webview/utils/view-types.ts
+++ b/src/webview/utils/view-types.ts
@@ -38,6 +38,7 @@ export function dispose(disposable: { dispose(): unknown }): void {
 export interface Decoration {
     range: BigIntMemoryRange;
     style: React.CSSProperties;
+    classNames: string[];
 }
 
 export function areDecorationsEqual(one: Decoration, other: Decoration): boolean {

--- a/src/webview/utils/window.ts
+++ b/src/webview/utils/window.ts
@@ -14,6 +14,8 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+import { isOSX } from '../../common/os';
+
 /**
  * Calculates the width of the element without any padding / margin / border
  */
@@ -41,4 +43,31 @@ export function characterWidthInContainer(container: HTMLElement, text: string):
     }
 
     return width;
+}
+
+/**
+ * Bare minimum common interface of the keyboard and the mouse event with respect to the key maskings.
+ * Taken from https://github.com/eclipse-theia/theia/blob/266fa0b2a9cf2649ed9b34c8b71b786806e787b4/packages/core/src/browser/tree/tree-widget.tsx#L141
+ */
+export interface ModifierAwareEvent {
+    /**
+     * Determines if the modifier aware event has the `meta` key masking.
+     */
+    readonly metaKey: boolean;
+    /**
+     * Determines if the modifier aware event has the `ctrl` key masking.
+     */
+    readonly ctrlKey: boolean;
+    /**
+     * Determines if the modifier aware event has the `shift` key masking.
+     */
+    readonly shiftKey: boolean;
+}
+
+/**
+ * Determine if the tree modifier aware event has a `ctrlcmd` mask.
+ * Taken from https://github.com/eclipse-theia/theia/blob/266fa0b2a9cf2649ed9b34c8b71b786806e787b4/packages/core/src/browser/tree/tree-widget.tsx#L1399
+ */
+export function hasCtrlCmdMask(event: ModifierAwareEvent): boolean {
+    return isOSX ? event.metaKey : event.ctrlKey;
 }

--- a/src/webview/variables/variable-decorations.ts
+++ b/src/webview/variables/variable-decorations.ts
@@ -33,7 +33,7 @@ import { messenger } from '../view-messenger';
 const NON_HC_COLORS = [
     'var(--vscode-terminal-ansiBlue)',
     'var(--vscode-terminal-ansiGreen)',
-    'var(--vscode-terminal-ansiRed)',
+    'var(--vscode-terminal-ansiBrightRed)',
     'var(--vscode-terminal-ansiYellow)',
     'var(--vscode-terminal-ansiMagenta)',
 ] as const;
@@ -132,12 +132,14 @@ export class VariableDecorator implements ColumnContribution, Decorator {
         let colorIndex = 0;
         for (const variable of this.currentVariables ?? []) {
             if (variable.endAddress) {
+                const idx = colorIndex++ % 5;
                 decorations.push({
                     range: {
                         startAddress: variable.startAddress,
                         endAddress: variable.endAddress
                     },
-                    style: { color: NON_HC_COLORS[colorIndex++ % 5] }
+                    style: {},
+                    classNames: ['variable-' + idx]
                 });
             }
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1055,6 +1055,11 @@ deepmerge@^2.1.1:
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.2.1.tgz#5d3ff22a01c00f645405a2fbc17d0778a1801170"
   integrity sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA==
 
+deepmerge@^4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.3.1.tgz#44b5f2147cd3b00d4b56137685966f26fd25dd4a"
+  integrity sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==
+
 define-properties@^1.1.3, define-properties@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.4.tgz#0b14d7bd7fbeb2f3572c3a7eda80ea5d57fb05b1"


### PR DESCRIPTION
#### What it does
Introduce group-level selection and navigation for table
- Disable row and cell navigation and selection
- Introduce custom selection and navigation handling based on groups
- Select a group by hitting 'Enter'
- Edit a group by hitting 'Space' (only available for data groups)
- Support copying data from the groups using Ctrl+C and Ctrl+X
- Only allow single selection for now

Relates to https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/issues/106 but does not include quick navigation up and down with PageUp/PageDown/Home/End/etc keys.

#### How to test
- Click on any cell/group and navigate with the keyboard arrow keys
- Select with 'Enter', edit (if available) with 'Space'

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the contribution guidelines](https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/blob/main/CONTRIBUTING.md)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the code of conduct](https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/blob/main/CODE_OF_CONDUCT.md)
