### PR TITLE
Increase group gap

### DIFF
--- a/media/memory-table.css
+++ b/media/memory-table.css
@@ -165,7 +165,7 @@
 
 .byte-group {
   font-family: var(--vscode-editor-font-family);
-  margin-right: 2px;
+  margin-right: 4px;
   padding: 0 1px; /* we use this padding to balance out the 2px that are needed for the editing */
 }
 

--- a/src/webview/columns/data-column.tsx
+++ b/src/webview/columns/data-column.tsx
@@ -226,8 +226,8 @@ export class EditableDataColumnRow extends React.Component<EditableDataColumnRow
 
 export namespace DataColumn {
     export namespace Styles {
-        // `margin-right: 2px` per group (see memory-table.css)
-        export const MARGIN_RIGHT_PX = 2;
+        // `margin-right: 4px` per group (see memory-table.css)
+        export const MARGIN_RIGHT_PX = 4;
         // `padding: 0 1px` applies 1px right and left per group (see memory-table.css)
         export const PADDING_RIGHT_LEFT_PX = 2;
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/blob/main/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Users have reported that the current gap between groups can be a bit small, especially when groups are large and / or there are many groups / row. This increases the gap between groups by another 2px.

Before:

![image](https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/assets/62660806/cf8654f2-408b-4113-ae73-b19be7d0244f)

After:

![image](https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/assets/62660806/04dd2f3b-8346-47d7-9df6-44738c4f5315)

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Confirm the slightly larger gap between groups.
2. Check that editing / line unbreakability is maintained with the new values.
3. Decide whether you like the bigger gap - it could be shifted to a preference, or left as is.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the contribution guidelines](https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/blob/main/CONTRIBUTING.md)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the code of conduct](https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/blob/main/CODE_OF_CONDUCT.md)
