### PR TITLE
Reduce hit target of more memory loader

### DIFF
--- a/src/webview/components/memory-table.tsx
+++ b/src/webview/components/memory-table.tsx
@@ -468,7 +468,7 @@ export class MemoryTable extends React.PureComponent<MemoryTableProps, MemoryTab
 
         if (this.props.memory !== undefined) {
             const prependScrollingBehaviors: ScrollingBehavior[] = ['Grow', 'Auto-Append'];
-            memorySelect = <div className='flex-auto'>
+            memorySelect = <div className='flex flex-auto justify-content-center'>
                 <MoreMemorySelect
                     activeReadArguments={this.props.activeReadArguments}
                     options={[128, 256, 512]}
@@ -499,7 +499,7 @@ export class MemoryTable extends React.PureComponent<MemoryTableProps, MemoryTab
         let memorySelect: React.ReactNode | undefined;
 
         if (this.props.memory !== undefined) {
-            memorySelect = <div className='flex-auto'>
+            memorySelect = <div className='flex flex-auto justify-content-center'>
                 <MoreMemorySelect
                     activeReadArguments={this.props.activeReadArguments}
                     options={[128, 256, 512]}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/blob/main/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #134

The previous code didn't set the header wrapping div to be flex, and it didn't justify content itself, meaning that the 'more memory loader' took up the full width.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Confirm that the hit target of the more memory loader is limited to the text itself.

> Alternatively, the more memory renderer could wrap itself so that it still took up the whole width, but only the text was the hit target. If this seems preferable, it can be implemented.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the contribution guidelines](https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/blob/main/CONTRIBUTING.md)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the code of conduct](https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/blob/main/CODE_OF_CONDUCT.md)
