### PR TITLE
More memory select cursor -> pointer

### DIFF
--- a/media/memory-table.css
+++ b/media/memory-table.css
@@ -50,7 +50,8 @@
   font-style: italic;
 }
 
-.more-memory-select:not(.p-disabled) {
+.more-memory-select:not(.p-disabled),
+.more-memory-select:not(.p-disabled) select {
   cursor: pointer;
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/blob/main/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #144 by making the cursor for the select element a pointer.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Open a memory inspector view and load memory.
2. Move your cursor over the select element in the More Memory loading bar.
3. Observe that it's a pointer.

#### Review checklist

- [ ] as an author, I have thoroughly tested my changes and carefully followed [the contribution guidelines](https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/blob/main/CONTRIBUTING.md)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the code of conduct](https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/blob/main/CODE_OF_CONDUCT.md)
