### PR TITLE
Don't render until initial data loaded

### DIFF
--- a/src/plugin/memory-webview-main.ts
+++ b/src/plugin/memory-webview-main.ts
@@ -163,14 +163,14 @@ export class MemoryWebview implements vscode.CustomReadonlyEditorProvider {
         }
 
         // Set HTML content
-        await this.getWebviewContent(panel);
+        await this.getWebviewContent(panel, initialMemory);
 
         // Sets up an event listener to listen for messages passed from the webview view context
         // and executes code based on the message that is received
         this.setWebviewMessageListener(panel, initialMemory);
     }
 
-    protected async getWebviewContent(panel: vscode.WebviewPanel): Promise<void> {
+    protected async getWebviewContent(panel: vscode.WebviewPanel, initialMemory?: MemoryOptions): Promise<void> {
         const mainUri = panel.webview.asWebviewUri(vscode.Uri.joinPath(
             this.extensionUri,
             'dist',
@@ -194,7 +194,7 @@ export class MemoryWebview implements vscode.CustomReadonlyEditorProvider {
                     <link href="${memoryInspectorCSS}" rel="stylesheet" />
                 </head>
                 <body>
-                    <div id='root'></div>
+                    <div id='root'></div>${initialMemory ? `<div id='initial-data' data-options='${JSON.stringify(initialMemory)}'></div>` : ''}
                 </body>
             </html>
         `;
@@ -206,7 +206,6 @@ export class MemoryWebview implements vscode.CustomReadonlyEditorProvider {
             this.messenger.onNotification(readyType, async () => {
                 this.setSessionContext(participant, this.createContext());
                 await this.setMemoryDisplaySettings(participant, panel.title);
-                this.refresh(participant, options);
             }, { sender: participant }),
             this.messenger.onRequest(setOptionsType, newOptions => { options = { ...options, ...newOptions }; }, { sender: participant }),
             this.messenger.onRequest(logMessageType, message => outputChannelLogger.info('[webview]:', message), { sender: participant }),


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/blob/main/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #145 by not showing the main UI until the initial memory data is known.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Open a Memory Inspector view from the Variables view.
2. Observe that there is not a stage where Formik errors are shown indicating that Address and Count are required.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the contribution guidelines](https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/blob/main/CONTRIBUTING.md)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the code of conduct](https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/blob/main/CODE_OF_CONDUCT.md)
