### PR TITLE
Prefer workspace extension host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 
 ## 1.1.0
+- Switched preferred extension host to `workspace` to enable WSL support
+
+## 1.1.0
 - Fixed variable fetch before variables are available.
 - Fixed variable decoration display if it starts before the loaded memory range.
 - Fixed `Memory: Show Memory Inspector` command to open a new Memory Inspector window instance instead of the `Output` channel.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "memory-inspector",
   "displayName": "Memory Inspector",
   "description": "A powerful and configurable memory viewer that works with debug adapters",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "publisher": "eclipse-cdt",
   "author": "Rob Moran <rob.moran@arm.com>",
   "license": "EPL-2.0",
@@ -444,6 +444,7 @@
     "onStartupFinished"
   ],
   "extensionKind": [
+    "workspace",
     "ui"
   ]
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/blob/main/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
This changes the exensionKind so that the extension prefers to run in the workspace. This enables remote VS Code sessions (e.g. WSL, ssh-remote, codespaces) to execute the memory inspector in the workspace where the debugger is more likely to be. Fixes #150 

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Run a debugger in WSL and use this extension

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the contribution guidelines](https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/blob/main/CONTRIBUTING.md)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the code of conduct](https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/blob/main/CODE_OF_CONDUCT.md)
