### PR TITLE
Add support for switching debug sessions

### DIFF
--- a/media/options-widget.css
+++ b/media/options-widget.css
@@ -77,19 +77,20 @@
   padding-bottom: 16px;
 }
 
-.form-textfield > input {
+.form-textfield>input {
   width: 150px;
 }
 
-.form-texfield-long > input {
+.form-texfield-long>input {
   width: 200px;
 }
 
 .form-options button[type="submit"] {
   /* Match height of inputs */
   height: calc(var(--input-minHeight) * 1px);
-  margin-top: 1rem;
+  margin-top: 1.1rem;
   align-self: start;
+  margin-right: auto;
 }
 
 .form-options-memory-read-argument-hint {
@@ -106,7 +107,7 @@
   font-size: 11px;
   text-transform: uppercase;
   line-height: 22px;
-  margin:0;
+  margin: 0;
   font-weight: normal;
 }
 
@@ -145,10 +146,14 @@
   padding-bottom: 0.5rem;
 }
 
-.advanced-options-toggle {
-  margin-left: auto;
+.advanced-options-session {
   align-self: start;
-  margin-top: 1.1rem
+  width: 250px;
+}
+
+.advanced-options-toggle {
+  align-self: start;
+  margin-top: 1.3rem
 }
 
 .p-accordion-content .advanced-options-content {
@@ -187,6 +192,7 @@
   margin-top: 0px;
   width: 210px;
 }
+
 .advanced-options-panel::-webkit-scrollbar-track {
   background-color: var(--vscode-dropdown-listBackground);
 }

--- a/src/common/messaging.ts
+++ b/src/common/messaging.ts
@@ -38,6 +38,11 @@ export type StoreMemoryResult = void;
 export type ApplyMemoryArguments = URI | undefined;
 export type ApplyMemoryResult = MemoryOptions;
 
+export interface Session {
+    id: string
+    name: string;
+}
+
 export interface SessionContext {
     sessionId?: string;
     canRead: boolean;
@@ -50,6 +55,8 @@ export const readyType: NotificationType<void> = { method: 'ready' };
 export const setMemoryViewSettingsType: NotificationType<Partial<MemoryViewSettings>> = { method: 'setMemoryViewSettings' };
 export const setTitleType: NotificationType<string> = { method: 'setTitle' };
 export const memoryWrittenType: NotificationType<WrittenMemory> = { method: 'memoryWritten' };
+export const sessionsChangedType: NotificationType<Session[]> = { method: 'sessionsChanged' };
+export const setSessionType: NotificationType<string> = { method: 'setSession' };
 export const sessionContextChangedType: NotificationType<SessionContext> = { method: 'sessionContextChanged' };
 
 // Requests

--- a/src/entry-points/browser/extension.ts
+++ b/src/entry-points/browser/extension.ts
@@ -18,7 +18,7 @@ import * as vscode from 'vscode';
 import { AdapterRegistry } from '../../plugin/adapter-registry/adapter-registry';
 import { CAdapter } from '../../plugin/adapter-registry/c-adapter';
 import { ContextTracker } from '../../plugin/context-tracker';
-import { MemoryProvider } from '../../plugin/memory-provider';
+import { MemoryProviderManager } from '../../plugin/memory-provider-manager';
 import { MemoryStorage } from '../../plugin/memory-storage';
 import { MemoryWebview } from '../../plugin/memory-webview-main';
 import { SessionTracker } from '../../plugin/session-tracker';
@@ -27,14 +27,14 @@ export const activate = async (context: vscode.ExtensionContext): Promise<Adapte
     const registry = new AdapterRegistry();
     const sessionTracker = new SessionTracker();
     new ContextTracker(sessionTracker);
-    const memoryProvider = new MemoryProvider(registry, sessionTracker);
-    const memoryView = new MemoryWebview(context.extensionUri, memoryProvider, sessionTracker);
-    const memoryStorage = new MemoryStorage(memoryProvider);
+    const memoryProviderManager = new MemoryProviderManager(registry, sessionTracker);
+    const memoryStorage = new MemoryStorage(sessionTracker, memoryProviderManager);
+    const memoryView = new MemoryWebview(context.extensionUri, memoryProviderManager, sessionTracker, memoryStorage);
     const cAdapter = new CAdapter(registry);
 
     registry.activate(context);
     sessionTracker.activate(context);
-    memoryProvider.activate(context);
+    memoryProviderManager.activate(context);
     memoryView.activate(context);
     memoryStorage.activate(context);
     cAdapter.activate(context);

--- a/src/entry-points/desktop/extension.ts
+++ b/src/entry-points/desktop/extension.ts
@@ -18,7 +18,7 @@ import * as vscode from 'vscode';
 import { AdapterRegistry } from '../../plugin/adapter-registry/adapter-registry';
 import { CAdapter } from '../../plugin/adapter-registry/c-adapter';
 import { ContextTracker } from '../../plugin/context-tracker';
-import { MemoryProvider } from '../../plugin/memory-provider';
+import { MemoryProviderManager } from '../../plugin/memory-provider-manager';
 import { MemoryStorage } from '../../plugin/memory-storage';
 import { MemoryWebview } from '../../plugin/memory-webview-main';
 import { SessionTracker } from '../../plugin/session-tracker';
@@ -27,14 +27,14 @@ export const activate = async (context: vscode.ExtensionContext): Promise<Adapte
     const registry = new AdapterRegistry();
     const sessionTracker = new SessionTracker();
     new ContextTracker(sessionTracker);
-    const memoryProvider = new MemoryProvider(registry, sessionTracker);
-    const memoryView = new MemoryWebview(context.extensionUri, memoryProvider, sessionTracker);
-    const memoryStorage = new MemoryStorage(memoryProvider);
+    const memoryProviderManager = new MemoryProviderManager(registry, sessionTracker);
+    const memoryStorage = new MemoryStorage(sessionTracker, memoryProviderManager);
+    const memoryView = new MemoryWebview(context.extensionUri, memoryProviderManager, sessionTracker, memoryStorage);
     const cAdapter = new CAdapter(registry);
 
     registry.activate(context);
     sessionTracker.activate(context);
-    memoryProvider.activate(context);
+    memoryProviderManager.activate(context);
     memoryView.activate(context);
     memoryStorage.activate(context);
     cAdapter.activate(context);

--- a/src/plugin/memory-provider-manager.ts
+++ b/src/plugin/memory-provider-manager.ts
@@ -1,0 +1,47 @@
+/********************************************************************************
+ * Copyright (C) 2025 Ericsson, Arm and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import * as vscode from 'vscode';
+import { AdapterRegistry } from './adapter-registry/adapter-registry';
+import { MemoryProvider } from './memory-provider';
+import { SessionTracker } from './session-tracker';
+
+export class MemoryProviderManager {
+
+    protected memoryProviders = new Map<vscode.DebugSession, MemoryProvider>();
+
+    constructor(protected adapterRegistry: AdapterRegistry, protected sessionTracker: SessionTracker) {
+    }
+
+    public activate(context: vscode.ExtensionContext): void {
+        const createDebugAdapterTracker = (session: vscode.DebugSession): vscode.ProviderResult<vscode.DebugAdapterTracker> => {
+            const handlerForSession = this.adapterRegistry.getHandlerForSession(session.type);
+            const contributedTracker = handlerForSession?.initializeAdapterTracker?.(session);
+            return contributedTracker;
+        };
+        context.subscriptions.push(vscode.debug.registerDebugAdapterTrackerFactory('*', { createDebugAdapterTracker }));
+    }
+
+    public getProvider(sessionId: string | undefined): MemoryProvider {
+        const session = this.sessionTracker.assertSession(sessionId);
+
+        if (!this.memoryProviders.has(session)) {
+            this.memoryProviders.set(session, new MemoryProvider(session.id, this.adapterRegistry, this.sessionTracker));
+        }
+
+        return this.memoryProviders.get(session)!;
+    }
+}

--- a/src/plugin/session-tracker.ts
+++ b/src/plugin/session-tracker.ts
@@ -139,30 +139,26 @@ export class SessionTracker implements vscode.DebugAdapterTrackerFactory {
         }
     }
 
-    get activeSession(): vscode.DebugSession | undefined {
-        return vscode.debug.activeDebugSession;
-    }
-
-    assertActiveSession(action: string = 'get session'): vscode.DebugSession {
-        if (!this.activeSession) {
+    assertSession(sessionId: string | undefined, action: string = 'get session'): vscode.DebugSession {
+        if (!sessionId || !this._sessionInfo.has(sessionId)) {
             throw new Error(`Cannot ${action}. No active debug session.`);
         }
-        return this.activeSession;
+        return this._sessionInfo.get(sessionId)!.raw;
     }
 
-    isActive(session = this.activeSession): boolean {
+    isActive(session: vscode.DebugSession): boolean {
         return !!session && vscode.debug.activeDebugSession?.id === session?.id;
     }
 
-    isStopped(session = this.activeSession): boolean {
+    isStopped(session: vscode.DebugSession): boolean {
         return !!session && !!this.sessionInfo(session).stopped;
     }
 
-    hasDebugCapability(session = this.activeSession, capability: DebugCapability): boolean {
+    hasDebugCapability(session: vscode.DebugSession, capability: DebugCapability): boolean {
         return !!session && !!this.sessionInfo(session).debugCapabilities?.[capability];
     }
 
-    assertDebugCapability(session = this.assertActiveSession(), capability: DebugCapability, action: string = 'execute action'): vscode.DebugSession {
+    assertDebugCapability(session: vscode.DebugSession, capability: DebugCapability, action: string = 'execute action'): vscode.DebugSession {
         if (!this.hasDebugCapability(session, capability)) {
             throw new Error(`Cannot ${action}. Session does not have capability '${capability}'.`);
         }
@@ -173,7 +169,7 @@ export class SessionTracker implements vscode.DebugAdapterTrackerFactory {
         return !!session && !!this.sessionInfo(session).clientCapabilities?.[capability];
     }
 
-    assertClientCapability(session = this.assertActiveSession(), capability: ClientCapability, action: string = 'execute action'): vscode.DebugSession {
+    assertClientCapability(session: vscode.DebugSession, capability: ClientCapability, action: string = 'execute action'): vscode.DebugSession {
         if (!this.hasClientCapability(session, capability)) {
             throw new Error(`Cannot ${action}. Client does not have capability '${capability}'.`);
         }

--- a/src/plugin/session-tracker.ts
+++ b/src/plugin/session-tracker.ts
@@ -17,6 +17,7 @@ import { DebugProtocol } from '@vscode/debugprotocol';
 import * as vscode from 'vscode';
 import { isDebugEvent, isDebugRequest, isDebugResponse } from '../common/debug-requests';
 import { WrittenMemory } from '../common/memory-range';
+import type { Session } from '../common/messaging';
 
 export interface SessionInfo {
     raw: vscode.DebugSession;
@@ -52,11 +53,16 @@ export interface SessionContinuedEvent extends SessionEvent {
     session: SessionInfo;
 }
 
+export interface SessionsChangedEvent extends SessionEvent {
+    event: 'changed';
+}
+
 export interface SessionEvents {
     'active': ActiveSessionChangedEvent,
     'memory-written': SessionMemoryWrittenEvent,
     'continued': SessionContinuedEvent,
     'stopped': SessionStoppedEvent
+    'changed': SessionsChangedEvent
 }
 
 export type DebugCapability = keyof DebugProtocol.Capabilities;
@@ -95,7 +101,10 @@ export class SessionTracker implements vscode.DebugAdapterTrackerFactory {
         let info = this._sessionInfo.get(session.id);
         if (!info) {
             info = { raw: session };
-            this._sessionInfo.set(session.id, info);
+            if (this._sessionInfo.has(session.id)) {
+                // Only update session if it is active
+                this._sessionInfo.set(session.id, info);
+            }
         }
         return info;
     }
@@ -113,10 +122,12 @@ export class SessionTracker implements vscode.DebugAdapterTrackerFactory {
 
     protected async sessionWillStart(session: vscode.DebugSession): Promise<void> {
         this._sessionInfo.set(session.id, { raw: session });
+        this.fireSessionEvent(session, 'changed', undefined);
     }
 
     protected sessionWillStop(session: vscode.DebugSession): void {
         this._sessionInfo.delete(session.id);
+        this.fireSessionEvent(session, 'changed', undefined);
     }
 
     protected willSendClientMessage(session: vscode.DebugSession, message: unknown): void {
@@ -137,6 +148,11 @@ export class SessionTracker implements vscode.DebugAdapterTrackerFactory {
         } else if (isDebugEvent('memory', message)) {
             this.fireSessionEvent(session, 'memory-written', message.body);
         }
+    }
+
+    public getSessions(): Session[] {
+        return Array.from(this._sessionInfo.values())
+            .map(info => ({ id: info.raw.id, name: info.raw.name }));
     }
 
     assertSession(sessionId: string | undefined, action: string = 'get session'): vscode.DebugSession {

--- a/src/webview/components/memory-widget.tsx
+++ b/src/webview/components/memory-widget.tsx
@@ -18,7 +18,7 @@ import React from 'react';
 import { WebviewIdMessageParticipant } from 'vscode-messenger-common';
 import * as manifest from '../../common/manifest';
 import { Memory } from '../../common/memory';
-import { WebviewSelection } from '../../common/messaging';
+import { Session, WebviewSelection } from '../../common/messaging';
 import { MemoryOptions, ReadMemoryArguments, SessionContext } from '../../common/messaging';
 import { MemoryDataDisplaySettings } from '../../common/webview-configuration';
 import { ColumnStatus } from '../columns/column-contribution-service';
@@ -30,6 +30,8 @@ import { OptionsWidget } from './options-widget';
 
 interface MemoryWidgetProps extends MemoryDataDisplaySettings {
     messageParticipant: WebviewIdMessageParticipant;
+    sessions: Session[];
+    updateSession: (sessionId: string) => void;
     sessionContext: SessionContext;
     configuredReadArguments: Required<ReadMemoryArguments>;
     activeReadArguments: Required<ReadMemoryArguments>;
@@ -87,6 +89,8 @@ export class MemoryWidget extends React.Component<MemoryWidgetProps, MemoryWidge
         return (<div className='flex flex-column h-full' {...this.createVscodeContext()}>
             <OptionsWidget
                 ref={this.optionsWidget}
+                sessions={this.props.sessions}
+                updateSession={this.props.updateSession}
                 sessionContext={this.props.sessionContext}
                 title={this.props.title}
                 updateTitle={this.props.updateTitle}

--- a/src/webview/components/options-widget.tsx
+++ b/src/webview/components/options-widget.tsx
@@ -76,7 +76,7 @@ const enum InputId {
     RefreshOnStop = 'refresh-on-stop',
     PeriodicRefresh = 'periodic-refresh',
     PeriodicRefreshInterval = 'periodic-refresh-interval',
-    Session = 'session'
+    SessionSelect = 'session-select'
 }
 
 interface OptionsForm {
@@ -170,15 +170,15 @@ export class OptionsWidget extends React.Component<OptionsWidgetProps, OptionsWi
 
         const sessionSelector = this.props.sessions.length <= 1 ? undefined :
             <span className='pm-top-label form-textfield'>
-                <label htmlFor={InputId.Session} className={`p-inputtext-label ${readDisabled ? 'p-disabled' : ''}`}>
+                <label htmlFor={InputId.SessionSelect} className={`p-inputtext-label ${readDisabled ? 'p-disabled' : ''}`}>
                     Debug Session
                 </label>
                 <Dropdown
-                    id={InputId.Session}
+                    id={InputId.SessionSelect}
                     className='advanced-options-session'
                     title='Debug Session'
                     aria-label='Debug Session'
-                    disabled={true}
+                    disabled={readDisabled}
                     options={this.props.sessions.map(session => ({ label: session.name, value: session.id }))}
                     value={this.props.sessionContext.sessionId}
                     onChange={this.handleSessionDropdownChange}

--- a/src/webview/memory-webview-view.tsx
+++ b/src/webview/memory-webview-view.tsx
@@ -33,12 +33,12 @@ import {
     readMemoryType,
     readyType,
     Session,
-    sessionsChangedType,
-    setSessionType,
     SessionContext,
     sessionContextChangedType,
+    sessionsChangedType,
     setMemoryViewSettingsType,
     setOptionsType,
+    setSessionType,
     setTitleType,
     showAdvancedOptionsType,
     storeMemoryType,
@@ -281,7 +281,7 @@ class App extends React.Component<{}, MemoryAppState> {
             sessionId
         });
         messenger.sendNotification(setSessionType, HOST_EXTENSION, sessionId);
-    }
+    };
 
     protected async setOptions(options?: MemoryOptions): Promise<void> {
         messenger.sendRequest(logMessageType, HOST_EXTENSION, `Setting options: ${JSON.stringify(options)}`);

--- a/src/webview/memory-webview-view.tsx
+++ b/src/webview/memory-webview-view.tsx
@@ -290,9 +290,6 @@ class App extends React.Component<{}, MemoryAppState> {
     }
 
     protected fetchMemory = async (partialOptions?: MemoryOptions): Promise<void> => {
-        // Ensure view has completed rendering
-        await new Promise(p => setTimeout(p, 0));
-
         if (this.state.isFrozen || !this.state.sessionContext.canRead) {
             return;
         }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/blob/main/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

May close https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/issues/67, https://github.com/eclipse-cdt-cloud/cdt-gdb-vscode/issues/110

Add dropdown to memory view when multiple debug sessions are active which allows the user to switch between the sessions. This enables multiple windows to target different debug sessions at the same time.

![Screenshot 2025-01-03 at 12 24 20](https://github.com/user-attachments/assets/12e8175d-7ee1-4e26-87ed-fe82706a691e)

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Open a few windows when there are multiple debug sessions active

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the contribution guidelines](https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/blob/main/CONTRIBUTING.md)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the code of conduct](https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/blob/main/CODE_OF_CONDUCT.md)

Re: https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/pull/133 Which attempted the same but using the amalgamator

cc @WyoTwT @jonahgraham 