### PR TITLE
updating js-yaml for security reasons

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,14 +80,6 @@
     "webpack": "^5.104.1",
     "webpack-cli": "^5.0.0"
   },
-  "resolutions": {
-    "@eslint/eslintrc/js-yaml": "^4.3.0",
-    "@vscode/vsce/@secretlint/node/@secretlint/config-loader/rc-config-loader/js-yaml": "^4.3.0",
-    "@vscode/vsce/@secretlint/node/@secretlint/formatter/@textlint/linter-formatter/js-yaml": "^4.3.0",
-    "eslint/js-yaml": "^4.3.0",
-    "mocha/js-yaml": "^4.3.0",
-    "tslint/js-yaml": "^3.15.0"
-  },
   "contributes": {
     "commands": [
       {

--- a/package.json
+++ b/package.json
@@ -80,6 +80,14 @@
     "webpack": "^5.104.1",
     "webpack-cli": "^5.0.0"
   },
+  "resolutions": {
+    "@eslint/eslintrc/js-yaml": "^4.3.0",
+    "@vscode/vsce/@secretlint/node/@secretlint/config-loader/rc-config-loader/js-yaml": "^4.3.0",
+    "@vscode/vsce/@secretlint/node/@secretlint/formatter/@textlint/linter-formatter/js-yaml": "^4.3.0",
+    "eslint/js-yaml": "^4.3.0",
+    "mocha/js-yaml": "^4.3.0",
+    "tslint/js-yaml": "^3.15.0"
+  },
   "contributes": {
     "commands": [
       {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3208,7 +3208,7 @@ jest-worker@^27.4.5:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@^3.13.1, js-yaml@^3.15.0:
+js-yaml@^3.13.1:
   version "3.15.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.15.1.tgz#24bc95028f361cdaaa84745b06a109c4486773c0"
   integrity sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==
@@ -3216,7 +3216,7 @@ js-yaml@^3.13.1, js-yaml@^3.15.0:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
-js-yaml@^4.1.0, js-yaml@^4.1.1, js-yaml@^4.3.0:
+js-yaml@^4.1.0, js-yaml@^4.1.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.1.tgz#01216c001d67f48e2cd560d708c7af21090a3848"
   integrity sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3208,18 +3208,18 @@ jest-worker@^27.4.5:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@^3.13.1:
-  version "3.14.2"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.2.tgz#77485ce1dd7f33c061fd1b16ecea23b55fcb04b0"
-  integrity sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==
+js-yaml@^3.13.1, js-yaml@^3.15.0:
+  version "3.15.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.15.1.tgz#24bc95028f361cdaaa84745b06a109c4486773c0"
+  integrity sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
-js-yaml@^4.1.0, js-yaml@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.1.tgz#854c292467705b699476e1a2decc0c8a3458806b"
-  integrity sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==
+js-yaml@^4.1.0, js-yaml@^4.1.1, js-yaml@^4.3.0:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.1.tgz#01216c001d67f48e2cd560d708c7af21090a3848"
+  integrity sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==
   dependencies:
     argparse "^2.0.1"
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/blob/main/CONTRIBUTING.md
-->

There were multiple dependencies that were using an old vulnerable version of js-yaml. I updated that
js-yaml v3 is now resolved to ^3.15.0
js-yaml v4 is now resolved to ^4.3.0

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Updated package.json and yarn.lock to use a security patch of js-yaml

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Try out the memory inspector and make sure it's still working as expected

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the contribution guidelines](https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/blob/main/CONTRIBUTING.md)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the code of conduct](https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/blob/main/CODE_OF_CONDUCT.md)
